### PR TITLE
Update with 2017-11-30 data

### DIFF
--- a/R/update-2017-11-30.R
+++ b/R/update-2017-11-30.R
@@ -1,0 +1,137 @@
+# Update the list with the data from 2017-10-31,
+# in particular combining all housing associations into a single 'en bloc'
+# record.
+
+library(tidyverse)
+library(readxl)
+library(stringr)
+library(RegistersClientR)
+library(lubridate)
+library(here)
+
+map_path <- here("lists", "name-to-curie-map.tsv")
+old_list_path <- here("lists", "list-2017-10-31.xls")
+new_list_path <- here("lists", "list-2017-11-30.xls")
+new_records_path <- here("lists", "new-records-2017-11-30.tsv")
+public_body_path <- here("data", "public-body.tsv")
+
+old_map <- read_tsv(map_path)
+old_register <-
+  rr_records("public-body", "alpha") %>%
+  select(`public-body`, name, organisations, `public-body-classifications`, `start-date`, `end-date`)
+# old_register <-
+#   read_tsv(here("lists", "register-2017-12-06.tsv")) %>%
+#   select(`public-body`, name, organisations, `public-body-classifications`, `start-date`, `end-date`)
+
+old_list <-
+  read_excel(old_list_path, sheet = 8, range = "A5:D3025") %>%
+    select(Institutions,
+           Sector,
+           `ESA10 category`,
+           `Classification applies from`) %>%
+    rename(name = Institutions,
+           sector = Sector,
+           `esa-2010` = `ESA10 category`,
+           `start-date` = `Classification applies from`)
+
+new_list <-
+  read_excel(new_list_path, sheet = 8, range = "A5:D3026") %>%
+    select(Institutions,
+           Sector,
+           `ESA10 category`,
+           `Classification applies from`) %>%
+    rename(name = Institutions,
+           sector = Sector,
+           `esa-2010` = `ESA10 category`,
+           `start-date` = `Classification applies from`)
+
+# Compare old list with new list
+
+still_exist <- inner_join(old_list, new_list, by = "name")
+removed <- anti_join(old_list, new_list, by = "name")
+added <- anti_join(new_list, old_list, by = "name")
+
+new_classification <- filter(still_exist, `esa-2010.x` != `esa-2010.y`)
+new_sector <- filter(still_exist, `sector.x` != `sector.y`)
+
+different_start_date <- filter(still_exist, `start-date.x` != `start-date.y`)
+new_start_date <- filter(still_exist, is.na(`start-date.x`), !is.na(`start-date.y`))
+removed_start_date <- filter(still_exist, !is.na(`start-date.x`), is.na(`start-date.y`))
+
+# Look at the changes
+removed
+added
+new_classification
+new_sector
+different_start_date
+new_start_date
+removed_start_date
+
+# This month's changes (comparing old list with new list)
+
+# "Private registered providers (PRPs) of social housing in England Public Non-Financial Corporation"
+# 5860
+# Name changed to: "Private registered providers' of social housing (including most housing associations) in England"
+# Reclassified as not-public-body on 2017-11-16 (to be end-dated)
+
+# "Crown Estate Scotland (Interim Management)"
+# Added on 2017-04-01 (to be start-dated)
+# Classified as S.11001
+
+# "Food from Britain"
+# 1239
+# Reclassified from S.1.311 to S.1311 (old version was a typo that was missed)
+# Reclassified from "Central Government" to "Former Central Government" on 2014-07-18 (to be end-dated)
+
+# "Commission for Rural Communities"
+# 1117
+# Reclassified from "Central Government" to "Former Central Government" on 2013-03-31 (to be end-dated)
+
+# "Committee on Agricultural Valuation"
+# 4146
+# Reclassified from "Central Government" to "Former Central Government" on 2014-04-23 (to be end-dated)
+
+# Complete the missing maps in the old register, e.g. Aberdeen City Council
+# should map to a government organisation
+old_register_with_all_maps <-
+  old_register %>%
+  left_join(select(old_map, `public-body`, name, organisation), by = "public-body") %>%
+  mutate(organisations = if_else(is.na(organisations), organisation, organisations)) %>%
+  select(-organisation, -name.y) %>%
+  rename(name = name.x) %>%
+  mutate(name = if_else(is.na(organisations), name, NA_character_))
+write_tsv(old_register_with_all_maps, here("data", "new-register-with-all-maps.tsv"))
+
+# Records in the old register that aren't in the map
+old_register_unmapped <-
+  old_register_with_all_maps %>%
+  left_join(select(old_map, `public-body`, name), by = "public-body") %>%
+  filter(is.na(name.y))
+
+# Compare old register with new list
+old_register_with_all_names <-
+  old_register_with_all_maps %>%
+  left_join(select(old_map, `public-body`, name), by = "public-body") %>%
+  select(`public-body`, name = name.y, `esa-2010` = `public-body-classifications`, `start-date`, `end-date`)
+
+still_exist <- inner_join(old_register_with_all_names, new_list, by = "name")
+removed <- anti_join(old_register_with_all_names, new_list, by = "name")
+added <- anti_join(new_list, old_register_with_all_names, by = "name")
+
+new_classification <- filter(still_exist, `esa-2010.x` != `esa-2010.y`)
+
+# new sector and dates can't be detected here, because there are so many records
+# that were already supposed to be end-dated when we got the first list, but the
+# list doesn't tell us the date they should have been end-dated.
+
+# Look at the changes
+removed
+added
+new_classification
+
+# All the 'removed' records actually just need to be added to the map file.
+# "Crown Estate (Scotland)" has already been covered by the old/new-list comparison.
+# "Green Investment Bank" actually just needs to be added to the map file (it's already there under a different name)
+# "Food From Britain" has already been covered by the old/new-list comparison.
+
+max(old_register$`public-body`)

--- a/data/public-body.tsv
+++ b/data/public-body.tsv
@@ -190,7 +190,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 2261	Aylesham and District Community Workshop Trust	NA	S.1313	NA	NA
 1033	NA	local-authority-eng:BAB	S.1313	NA	NA
 2266	Baileyfield Switch and Crossing Works	NA	S.11001	NA	NA
-2267	Bainsdown Ltd (s MA)	NA	S.11001/03	2013-02-01	NA
+2267	Bainsdown Ltd (s MA)	NA	S.11001;S.11003	2013-02-01	NA
 1034	NA	government-organisation:OT1016	S.121	NA	NA
 2275	Bank of Scotland plc	NA	S.12201	NA	2014-03-01
 2276	Banking Department	NA	S.121	NA	NA
@@ -303,10 +303,10 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 1050	NA	government-organisation:OT428	S.1311	NA	NA
 1051	NA	government-organisation:OT431	S.1311	NA	NA
 1885	NA	government-organisation:PB337	S.1311	NA	NA
-2428	Bournemouth Airport Property Investments (Industrial) Ltd	NA	S.11001/3	2013-02-01	NA
-2429	Bournemouth Airport Property Investments (Offices) Ltd	NA	S.11001/3	2013-02-01	NA
+2428	Bournemouth Airport Property Investments (Industrial) Ltd	NA	S.11001;S.11003	2013-02-01	NA
+2429	Bournemouth Airport Property Investments (Offices) Ltd	NA	S.11001;S.11003	2013-02-01	NA
 1052	NA	local-authority-eng:BMH	S.1313	NA	NA
-2431	Bournemouth International Airport Ltd (s MA)	NA	S.11001/3	2013-02-01	NA
+2431	Bournemouth International Airport Ltd (s MA)	NA	S.11001;S.11003	2013-02-01	NA
 2432	Bournemouth Transport Ltd	NA	S.11001	NA	NA
 2437	BPE Mechanical and Electrical Engineering Consultancy	NA	S.11001	NA	NA
 2438	BPEX Ltd	NA	S.1311	NA	NA
@@ -860,11 +860,11 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 1200	NA	local-authority-eng:ELI	S.1313	NA	NA
 4420	East London Waste Authority	NA	S.1313	1986-01-01	NA
 1870	NA	local-authority-sct:ELN	S.1313	NA	NA
-4422	East Midlands Airport (s MA)	NA	S.11001/3	2013-02-01	NA
-4423	East Midlands Airport Nottingham Derby Leicester Ltd	NA	S.11001/3	2013-02-01	NA
-4424	East Midlands Airport Property Investments (Hotels) Ltd	NA	S.11001/3	2013-02-01	NA
-4425	East Midlands Airport Property Investments (Industrial) Ltd	NA	S.11001/3	2013-02-01	NA
-4426	East Midlands Airport Property Investments (Offices) Ltd	NA	S.11001/3	2013-02-01	NA
+4422	East Midlands Airport (s MA)	NA	S.11001;S.11003	2013-02-01	NA
+4423	East Midlands Airport Nottingham Derby Leicester Ltd	NA	S.11001;S.11003	2013-02-01	NA
+4424	East Midlands Airport Property Investments (Hotels) Ltd	NA	S.11001;S.11003	2013-02-01	NA
+4425	East Midlands Airport Property Investments (Industrial) Ltd	NA	S.11001;S.11003	2013-02-01	NA
+4426	East Midlands Airport Property Investments (Offices) Ltd	NA	S.11001;S.11003	2013-02-01	NA
 4427	East Midlands Cultural Consortium	NA	S.1311	NA	2010-09-01
 1740	NA	government-organisation:EA912	S.1311	NA	2012-07-01
 4429	East Midlands International Airport	NA	S.11001	NA	NA
@@ -1009,7 +1009,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 4600	Folkestone Sports Centre Trust Ltd	NA	S.1313	NA	NA
 4601	Food Advisory Committee	NA	S.1311	NA	NA
 1880	NA	government-organisation:EA56	S.1311	NA	2015-03-31
-1239	NA	government-organisation:OT793	S.1.311	NA	2014-07-18
+1239	NA	government-organisation:OT793	S.1311	NA	2014-07-18
 1240	NA	government-organisation:D102	S.1311	NA	NA
 4602	Food Standards Scotland	NA	S.1311	2015-04-01	NA
 1241	NA	government-organisation:OT787	S.1311	NA	NA
@@ -1571,14 +1571,14 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 3147	Manchester (Barton) Aerodrome	NA	S.1313	NA	NA
 3148	Manchester Airport Building Ltd (s MA)	NA	S.11001	NA	2006-07-01
 3149	Manchester Airport Employment Services Ltd (s MA)	NA	S.11001	NA	2006-07-01
-3150	Manchester Airport Finance Holdings Ltd	NA	S.11001/3	2013-02-01	NA
+3150	Manchester Airport Finance Holdings Ltd	NA	S.11001;S.11003	2013-02-01	NA
 3151	Manchester Airport Finance Ltd (s MA)	NA	S.11001	NA	2006-07-01
-3152	Manchester Airport Group Finance Ltd	NA	S.11001/3	2013-02-01	NA
-3153	Manchester Airport Group plc	NA	S.11001/3	2013-02-01	NA
-3154	Manchester Airport Group Property Developments Ltd	NA	S.11001/3	2013-02-01	NA
-3155	Manchester Airport Group Property Services Ltd	NA	S.11001/3	2013-02-01	NA
-3156	Manchester Airport Holdings Limited	NA	S.12701/03	2013-02-01	NA
-3157	Manchester Airport plc	NA	S.11001/3	2013-02-01	NA
+3152	Manchester Airport Group Finance Ltd	NA	S.11001;S.11003	2013-02-01	NA
+3153	Manchester Airport Group plc	NA	S.11001;S.11003	2013-02-01	NA
+3154	Manchester Airport Group Property Developments Ltd	NA	S.11001;S.11003	2013-02-01	NA
+3155	Manchester Airport Group Property Services Ltd	NA	S.11001;S.11003	2013-02-01	NA
+3156	Manchester Airport Holdings Limited	NA	S.12701;S.12703	2013-02-01	NA
+3157	Manchester Airport plc	NA	S.11001;S.11003	2013-02-01	NA
 1380	NA	local-authority-eng:MAN	S.1313	NA	NA
 3159	Manchester Investment and Development Agency Service Ltd	NA	S.1313	NA	NA
 1381	NA	local-authority-eng:MAS	S.1313	NA	NA
@@ -2280,8 +2280,8 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 1536	NA	local-authority-eng:RIB	S.1313	NA	NA
 1537	NA	local-authority-eng:RIH	S.1313	NA	NA
 5208	Ringway Developments Ltd	NA	S.1313	NA	NA
-5209	Ringway Handling Limited (s MA)	NA	S.11001/3	2013-02-01	NA
-5210	Ringway Handling Services Ltd (s MA)	NA	S.11001/3	2013-02-01	NA
+5209	Ringway Handling Limited (s MA)	NA	S.11001;S.11003	2013-02-01	NA
+5210	Ringway Handling Services Ltd (s MA)	NA	S.11001;S.11003	2013-02-01	NA
 5214	River Nith Navigation	NA	S.11001	NA	2015-12-02
 5215	River Yealm Harbour Authority	NA	S.11001	NA	NA
 5216	Rivers Agency (Northern Ireland)	NA	S.1311	NA	NA

--- a/data/public-body.tsv
+++ b/data/public-body.tsv
@@ -1214,8 +1214,8 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 2673	Historic Environment Advisory Council	NA	S.1311	NA	2010-07-01
 2674	Historic Environment Scotland	NA	S.1311	2015-10-01	NA
 2675	Historic Monuments Council (Northern Ireland)	NA	S.1311	NA	NA
-2676	NA	government-organisation:PC389	S.11001	NA	NA
-1758	NA	government-organisation:PC389	S.11001	NA	NA
+2676	Historic Royal Palaces Enterprises Ltd		S.11001	NA	NA
+1758	Historic Royal Palaces Trust		S.11001	NA	NA
 2677	Historic Scotland	NA	S.1311	NA	2015-04-01
 2678	Historical Manuscripts Commission (The Royal Commission on Historical Manuscripts)	NA	S.1311	NA	NA
 1846	HM Inspectorate of Education	NA	S.1311	NA	2011-04-01

--- a/data/public-body.tsv
+++ b/data/public-body.tsv
@@ -573,7 +573,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 4136	Commission for Local Administration in Wales	NA	S.1311	NA	NA
 4137	Commission for New Towns	NA	S.1311	NA	NA
 1116	NA	government-organisation:OT822	S.1311	NA	2008-06-01
-1117	NA	government-organisation:OT890	S.1311	NA	NA
+1117		government-organisation:OT890	S.1311	NA	2013-03-31
 1768	NA	government-organisation:OT824	S.1311	NA	2009-03-01
 4138	Commission for the New Economy Ltd	NA	S.1313	NA	NA
 4139	Commission for Victims and Survivors	NA	S.1311	2008-05-01	NA
@@ -585,7 +585,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 4143	Commissioners of Taxes for the City of London	NA	S.1313	NA	NA
 4144	Committee for Monitoring Agreements On Tobacco Advertising Sponsorship	NA	S.1311	NA	NA
 4145	Committee of Investigation for Great Britain	NA	S.1311	NA	NA
-4146	Committee on Agricultural Valuation	NA	S.1311	NA	NA
+4146	Committee on Agricultural Valuation		S.1311		2014-04-23
 4147	Committee on Appeals Criteria and Miscarriages of Justice	NA	S.1311	NA	NA
 4148	Committee on Carcinogenicity of Chemicals in Food, Consumer Products and the Environment	NA	S.1311	NA	NA
 1118	NA	government-organisation:PB196	S.1311	NA	NA
@@ -1009,7 +1009,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 4600	Folkestone Sports Centre Trust Ltd	NA	S.1313	NA	NA
 4601	Food Advisory Committee	NA	S.1311	NA	NA
 1880	NA	government-organisation:EA56	S.1311	NA	2015-03-31
-1239	NA	government-organisation:OT793	S.1.311	NA	NA
+1239	NA	government-organisation:OT793	S.1.311	NA	2014-07-18
 1240	NA	government-organisation:D102	S.1311	NA	NA
 4602	Food Standards Scotland	NA	S.1311	2015-04-01	NA
 1241	NA	government-organisation:OT787	S.1311	NA	NA
@@ -2170,7 +2170,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 5070	Prestwick Aviation Holdings Limited	NA	S.1311	2013-11-22	NA
 5071	Primary Care Trusts (En Bloc)	NA	S.1311	NA	2013-04-01
 5075	Priority Sites Ltd	NA	S.11001	2008-09-01	NA
-5860	Private registered providers (PRPs) of social housing in England	NA	S.11001	1996-07-24	NA
+5860	Private registered providers' of social housing (including most housing associations) in England	NA	S.11001	1996-07-24T00:00:00Z	2017-11-16T00:00:00Z
 1522	NA	government-organisation:OT342	S.1311	NA	NA
 1523	NA	government-organisation:OT659	S.1311	NA	NA
 5076	Probation Trusts	NA	S.1311	NA	NA
@@ -3019,3 +3019,4 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 1711	NA	government-organisation:PB302	S.1311	NA	NA
 3946	Zetland Transport Partnership	NA	S.1313	2005-12-01	NA
 3947	Zoos Forum	NA	S.1311	NA	NA
+5864	Crown Estate Scotland (Interim Management)		S.11001	2017-04-01T00:00:00Z	NA

--- a/data/public-body.tsv
+++ b/data/public-body.tsv
@@ -1,3021 +1,3021 @@
 public-body	name	organisations	public-body-classifications	start-date	end-date
-3947	Zoos Forum		S.1311		
-3946	Zetland Transport Partnership		S.1313	2005-12-01	
-1711	Youth Justice Board for England and Wales		S.1311		
-1837	Youth Justice Agency (Northern Ireland)		S.1311		
-3943	Youth Council for Northern Ireland		S.1311		
-3942	Youth and Family Courts Lay Panel Advisory Committee (Northern Ireland)		S.1311		2004-10-01
-3940	Your Homes Newcastle Ltd		S.11001		
-3938	Young Persons Learning Agency for England		S.1311		2012-04-01
-3937	Yorkshire Region Electricity Consumers’ Committee		S.1311		
-3936	Yorkshire Purchasing Organisation		S.11001		
-3935	Yorkshire Metro Ltd - (s SYPTE)		S.11001		
-1710	Yorkshire Forward		S.1311		2012-07-01
-1709	Yorkshire Dales National Park Authority		S.1313	1996-06-01	
-3932	Yorkshire Cultural Consortium		S.1311		2009-07-01
-3930	Yorkshire & Humber Port		S.1313		
-1708	Wyre Forest District Council		S.1313		
-3910	Wyre Council		S.1313		
-1707	Wycombe District Council		S.1313		
-1706	Wychavon District Council		S.1313		
-1705	Wrexham County Borough Council		S.1313		
-1704	Worthing Borough Council		S.1313		
-3902	Worldwide Americas Investments Inc [USA] (s BBCW)		S.11001		
-3901	World Poultry Science Association		S.1311		
-3900	Worknorth Ltd (s MA)		S.11001		2013-02-01
-3899	Worknorth 11 Ltd (s MA)		S.11001		2013-02-01
-3898	Workington Port		S.1313		
-1767	Working Ventures UK (WVUK)		S.1311		2010-08-01
-3897	Workforce Development Confederations		S.1311		2004-04-01
-1703	Worcestershire County Council		S.1313		
-3895	Worcestershire County Association of Local Councils		S.1313		
-1702	Worcester City Council		S.1313		
-3893	Woolwich Arsenal Rail Enterprises Limited		S.1313	1905-07-03	
-3892	Woolwich Arsenal Rail Enterprises (Holdings) Limited		S.1313	1905-07-03	
-3886	Woodford-Gubbins Ltd - (s Remploy Ltd)		S.11001		
-3884	Women's National Commission		S.1311		
-3883	Wolverhampton Homes Ltd		S.11001		
-3882	Wolverhampton City Council		S.1313		
-3881	Wolverhampton City Challenge		S.1313		1998-03-01
-1701	Wokingham Borough Council		S.1313		
-1700	Woking Borough Council		S.1313		
-3876	WJEC CBAC Ltd (Welsh Joint Education Committee)		S.11001		
-3871	Wisbech Port		S.1313		
-3867	Wirral Council		S.1313		
-3862	Wine Standards Board of the Vintners' Company		S.1311		
-1699	Winchester City Council		S.1313		
-3857	Wimbledon Civic Theatre Trust		S.1313		
-1698	Wiltshire Council		S.1313		
-3856	Wilton Park International Advisory Council		S.1311		
-3855	Wilton Park Executive Agency		S.1311		
-3854	Wilton Park Academic Council		S.1311		
-3844	Wigtown Port		S.1313		
-1697	Wigan Metropolitan Borough Council		S.1313		
-3842	Wider Health Working Group		S.1311		
-3840	Wick Harbour		S.11001		2015-12-02
-3838	Whitwick Business Park Management Co Ltd, The		S.1313		
-3837	Whitstable Port		S.1313		
-3835	Whitehills Harbour		S.11001		2015-12-02
-3833	Whitehall Port (Stronsay)		S.1313		
-3830	Whitby Port		S.1313		
-3823	WGC Holdco Ltd		S.1311	2013-03-01	
-3822	Weymouth Port		S.1313		
-1696	Weymouth and Portland Borough Council		S.1313		
-3821	Weyland Farms Ltd		S.1313		
-3814	Westray Port		S.1313		
-1761	Westminster Foundation for Democracy Limited, The		S.1311		
-3811	Westminster City Council		S.1313		
-3808	Westinghouse Electric UK Limited		S.11001		
-3806	Western Riverside Waste Authority		S.1313	1986-01-01	
-3805	Western Health and Social Care Trust		S.1311	2010-04-01	
-1861	Western Health and Personal Social Services Board		S.1311		
-1695	Western Education and Library Board		S.1311		
-3803	West Yorkshire Passenger Transport Executive - (s PTE)		S.1313		
-3802	West Yorkshire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1694	West Sussex County Council		S.1313		
-1693	West Somerset District Council		S.1313		
-1692	West Oxfordshire District Council		S.1313		
-3799	West of Scotland Water Authority		S.11001		
-1691	West Northamptonshire Development Corporation		S.1311		2014-03-31
-3796	West North West Homes Leeds		S.11001		
-3795	West Midlands Passenger Transport Executive (trading as Centro) - (s PTE)		S.1313	1998-04-01	
-3794	West Midlands Life Cultural Consortium		S.1311		2010-09-01
-3792	West Lothian Municipal Bank Ltd		S.12501		
-1874	West Lothian Council		S.1313		
-3789	West London Waste Authority		S.1313	1986-01-01	
-1690	West Lindsey District Council		S.1313		
-1689	West Lancashire Borough Council		S.1313		
-1835	West Dunbartonshire Council		S.1313		
-1688	West Dorset District Council		S.1313		
-1687	West Devon Borough Council		S.1313		
-1686	West Berkshire Council		S.1313		
-3779	Welwyn Hatfield Community Housing trust Ltd		S.11001		
-1685	Welwyn Hatfield Borough Council		S.1313		
-3777	Welwyn Garden City - (s NTC)		S.1311		
-3776	Welsh Venture Capital - (s WDA)		S.11001		
-3775	Welsh Venture Capital		S.11001		
-3774	Welsh Scientific Advisory Committee		S.1311		
-3773	Welsh Scheme for the Development of Health and Social Research		S.1311		
-3772	Welsh Pharmaceutical Committee		S.1311		
-3771	Welsh Optometric Committee		S.1311		
-3770	Welsh Optical Committee		S.1311		
-3769	Welsh Nursing and Midwifery Committee		S.1311		
-3768	Welsh National Board for Nursing, Midwifery and Health Visiting		S.1311		2002-04-01
-3767	Welsh Medical Committee		S.1311		
-3766	Welsh Local Government Association		S.1313	1996-02-23	
-1684	Welsh Language Commissioner		S.1311	2012-04-01	
-3765	Welsh Language Board (WLB)		S.1311		2012-04-01
-3764	Welsh Industrial Development Advisory Board		S.1311		
-3763	Welsh Health Promotion Authority		S.1311		
-3762	Welsh Health Common Services Authority		S.1311		
-1683	Welsh Government		S.1311		
-3761	Welsh Further Education Colleges		S.1311		2015-01-27
-1682	Welsh Development Agency		S.1311		2006-04-01
-3760	Welsh Dental Committee		S.1311		
-3759	Welsh Consumer Council (WCC)		S.1311		
-3758	Welsh Community Health Councils		S.1311		
-3757	Welsh Committee for Professional Development of Pharmacy		S.1311		
-3756	Welsh Committee for Postgraduate Pharmaceutical Education		S.1311		
-3755	Welsh Blood Service		S.1311		
-3754	Welsh Ambulance Services NHS Trust		S.1311	1998-04-01	
-3753	Welsh Advisory Committee on Telecommunications (WACT)		S.1311		
-3752	Welsh Advisory Committee on Drug and Alcohol Misuse		S.1311		
-1681	Wellingborough Borough Council		S.1313		
-3743	WeatherXchange Limited		S.11001		2009-11-01
-1680	Wealden District Council		S.1313		
-1679	Waverley Borough Council		S.1313		
-1678	Waveney District Council		S.1313		
-1677	Watford Borough Council		S.1313		
-1676	Waterways Ireland		S.1311	1999-12-01	
-3737	Waterwatch Scotland		S.1311		2011-08-01
-3731	Water Regulations Advisory Committee		S.1311		
-3730	Water Industry Commission for Scotland		S.1311		
-3729	Water Appeals Commission (Northern Ireland)		S.1311		
-3728	Watchet Port		S.1313		
-3727	Waste Disposal		S.1313		
-3726	Waste & Resources Action Programme (WRAP)		S.1311		
-3725	Washington - (s NTC)		S.1311		
-1675	Warwickshire County Council		S.1313		
-3723	Warwickshire and West Mercia Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-3722	Warwick Technology Park Management Company Ltd		S.1313		
-1674	Warwick District Council		S.1313		
-1673	Warship Support Agency		S.1311		2004-04-01
-3719	Warrington Borough Transport Ltd		S.11001		
-1672	Warrington Borough Council		S.1313		
-3718	Warrington - (s NTC)		S.1311		
-3717	Warren Point Harbour Authority		S.11001		
-3715	War Pensions Committee		S.1311		2009-12-01
-3714	War Pensions Agency (admin)		S.1311		2007-04-01
-3709	Waltham Forest Arms Length Management Organisation Ltd		S.11001		
-1671	Walsall Metropolitan Borough Council		S.1313		
-1670	Wallace Collection		S.1311		
-3705	Wales Youth Agency		S.1311		
-3704	Wales Tourist Board		S.1311		
-3703	Wales Office		S.1311		
-3702	Wales Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1669	Wales Audit Office		S.11001		
-1668	Wakefield Metropolitan District Council		S.1313		
-3698	Wages Councils		S.1311		
-3695	Voluntary Controlled Schools (En Bloc)		S.1313	1999-11-01	
-3694	Voluntary Aided Schools (En Bloc)		S.1313		
-3693	Voluntary Action Camden		S.1313		
-3692	Voluntary Action Barnsley		S.1313		
-3690	VisitScotland Ltd		S.1311		
-1769	VisitBritain Ltd		S.1311		
-3685	Viking Energy Ltd		S.1313		
-3681	Victoria Coach Station Ltd (s.TfL)		S.11001		
-1667	Victoria and Albert Museum		S.1311		
-3679	Victims and Survivors Service Ltd		S.1311	2012-04-01	
-1666	Veterinary Residues Committee		S.1311		2015-03-31
-1665	Veterinary Products Committee		S.1311		
-1664	Veterinary Medicines Directorate		S.1311		
-1663	Veterinary Laboratories Agency		S.1311		
-1662	Veterans Advisory and Pensions Committees		S.1311	2009-12-01	
-3678	Verderers of the New Forest		S.1313		
-3677	Velindre NHS Trust		S.1311	1994-04-01	
-1661	Vehicle Certification Agency		S.1311		
-1732	Vehicle and Operator Services Agency (VOSA)		S.11001		
-3675	VAT and Duties Tribunal		S.1311		
-3673	Valuation Tribunals (Wales)		S.1311		
-3672	Valuation Tribunals		S.1311		
-1660	Valuation Office Agency		S.1311		
-1800	Valuation and Land Agency		S.1311		
-1659	Vale of White Horse District Council		S.1313		
-3670	Vale of Glamorgan Victim Support		S.1313		
-1658	Vale of Glamorgan Council		S.1313		
-3668	Vaccine Damage Tribunal		S.1311		
-1657	Uttlesford District Council		S.1313		
-3667	Urr Navigation		S.11001		2015-12-02
-3665	Urban Regeneration Agency		S.1311		
-3664	Urban Investment Grant Appraisal Panel		S.1311		
-3663	Urban Development Corporations		S.1311		
-3662	University Technical Colleges (en Bloc)		S.1311		
-3661	University for Industry Limited (renamed as Learndirect Ltd in April 2012)		S.1311		2012-11-01
-3660	University for Industry Charitable Trust		S.1311		2012-03-01
-3657	United Residents Housing Ltd		S.11001		
-3656	United Kingdom Xenotransplantation Interim Regulatory Authority (UK)		S.1311		2006-12-01
-3655	United Kingdom Transplant Support Service Authority		S.1311		
-3654	United Kingdom Sports Council, The (UK Sport)		S.1311		
-3653	United Kingdom Round Table on Sustainable Development		S.1311		
-3652	United Kingdom Register of Organic Food Standards		S.1311		
-3651	United Kingdom Nirex Ltd - (s NDA)		S.11001		
-3650	United Kingdom Eco-labelling Board		S.1311		
-3649	United Kingdom Border Agency		S.1311		2013-04-01
-3648	United Kingdom Atomic Energy Authority		S.1311		
-3647	United Kingdom Advisory Panel for Health Care Workers infected with bloodbourne viruses		S.1311		
-3645	Union Railways (South) Limited		S.11001		2011-09-01
-3644	Union Railways (North) Limited		S.11001		2008-07-01
-3643	Unified Appeal Tribunal		S.1311		
-3641	Unclaimed Stock and Dividends Account		S.1311		
-3640	Unclaimed Redemption Monies		S.1311		
-3639	Ulsterbus Ltd - (s NITHC)		S.11001		
-3638	Ulster Supported Employment Ltd		S.1311		
-3637	Ulster Savings Committee		S.1311		
-3636	Ulster Museum		S.1311		
-3635	Ulster Folk and Transport Museum		S.1311		
-3634	Ulster Countryside Agency		S.1311		
-3633	Ulster Bank Ltd		S.12201		
-3632	Ulster Bank Ireland Ltd		S.12201		
-3631	Ulster American Folk Park		S.1311		
-3630	Ullapool Harbour		S.11001		2015-12-02
-1856	UK Trade and Investment		S.1311		
-1783	UK Statistics Authority		S.1311		
-1656	UK Space Agency		S.1311	2011-04-01	
-3629	UK Robotic Ltd - (s BNFL)		S.11001		
-3628	UK Programme Distribution Ltd (95%) (s BBCW)		S.11001		
-3627	UK Medical Ventures Fund/MVM Limited		S.1311		
-3626	UK Human Genome Mapping Project resource centre		S.1311		
-1811	UK Financial Investments Ltd		S.1311		
-1655	UK Film Council		S.1311		2011-04-01
-1654	UK Debt Management Office		S.1311		
-1653	UK Commission for Employment and Skills		S.1311		
-3625	UK Central Council for Nursing, Midwifery and Health Visiting		S.1311		2002-04-01
-3624	UK Asset Resolution Ltd		S.1311	2010-10-01	
-1805	UK Anti Doping		S.1311	2009-08-01	
-3623	UIC Transport (JNP) Ltd		S.11001		1905-07-04
-3619	Tyne Harbour Commissioners		S.11001		
-3618	Tyne and Wear Passenger Transport Executive - (s PTE) - Nexus		S.1313	1998-04-01	
-3617	Tyne & Wear Development Corporation		S.11001		
-1652	Tunbridge Wells Borough Council		S.1313		
-3607	Tube Lines (Holdings) Ltd (including Tube Lines Ltd and Tube Lines Finance Plc)		S.1313	1905-07-02	
-3606	TSB Bank plc		S.12201		2014-03-01
-3605	TS Prestwick Holdco Ltd		S.1311	2013-11-14	
-3604	Trust Ports in Northern Ireland (En Bloc)		S.11001		
-3602	Truro Port		S.1313		
-5848	Tristar Homes Ltd		S.11001	1996-07-04	2010-12-01
-5845	Trinity House National Lighthouse Centre Ltd		S.1313		2006-08-01
-5844	Trinity House Lighthouse Service		S.1311	1905-04-29	
-5839	Tribunals Service, the		S.1311		2011-04-01
-5838	Tribunal under Schedule 11 of the Health and Personal Social Services (NI) Order 1972		S.1311		
-5833	Treasury Trove Reviewing Committee		S.1311		
-1651	Treasure Valuation Committee		S.1311		
-5832	Transport Tribunal		S.1311		
-5831	Transport Trading Ltd (s.TfL)		S.1313	1905-06-22	
-5830	Transport for London Pension Scheme		S.12901	1989-04-01	
-5829	Transport for London Finance Limited		S.1313	2008-11-01	
-5828	Transport for London		S.1313		
-5827	Transport for Greater Manchester		S.1313		
-5826	Transitional Child Trust Fund		S.1311		
-5824	Tramtrack Croydon Ltd		S.11001	2008-06-01	
-5823	Training and Enterprise Councils (En Bloc)		S.1311		
-5822	Training and Employment Agency (Advisory Board)		S.1311		
-1650	Training and Development Agency for Schools		S.1311		2012-04-01
-5821	Training and Development Agency		S.1311		
-5820	Trafford Park Development Corporation		S.11001		
-1649	Trafford Metropolitan Borough Council		S.1313		
-5818	Traffic Wardens		S.1313		
-5817	Traffic Director for London		S.1311		
-5816	Traffic Commissioners/ Licensing Authorities		S.1311		
-5811	Tower Hamlets Homes Ltd		S.11001		
-5809	Tourism Ireland Ltd		S.1311	1999-12-01	
-5808	Tote Direct Ltd - (s HTB)		S.11001		
-5807	Tote Credit Ltd - (s HTB)		S.11001		
-5806	Tote Bookmakers Ltd - (s HTB)		S.11001		
-1648	Torridge District Council		S.1313		
-5804	Torquay Port		S.1313		
-1647	Torfaen County Borough Council		S.1313		
-1646	Torbay Council		S.1313		
-5803	Topsham Port		S.1313		
-1645	Tonbridge and Malling Borough Council		S.1313		
-5795	Tingwall Aerodrome		S.1313		
-1644	Thurrock Thames Gateway Development Corporation		S.1311		2012-10-01
-1643	Thurrock Council		S.1313		
-1642	Three Rivers District Council		S.1313		
-5783	Theatres Trust		S.1311		
-5782	The Skills Development Scotland Co. Limited (t/a Skills Development Scotland)		S.1311		
-5781	The Scottish Association of Citizens Advice Bureau		S.1311		2013-11-01
-5780	The Potteries Box Company Ltd - (s Remploy Ltd)		S.11001		
-5779	The Nursery Channel Ltd. (S - S4C)		S.11001		
-5778	The North South Language Body (An Foras Teanga North-South Body o Leid)		S.1311	1999-12-01	
-5777	The National Institute for Health and Clinical Excellence		S.1311	2005-04-01	
-5776	The National Institute for Clinical Excellence		S.1311		2005-04-01
-5775	The National Association of Citizens Advice Bureau (England and Wales)		S.1311		2013-11-01
-5774	The London Authorities Mutual Limited		S.12801		
-5772	The Learning Trust		S.11001		
-5770	The English Heritage Trust		S.11001	2014-11-24	
-5769	The Crime Concern, Marks and Spencer, Groundwork Partnership (t/a Youth Works)		S.1311		
-5767	The Attorney General's Office		S.1311		
-1641	Thanet District Council		S.1313		
-5766	Thamesdown Transport Ltd		S.11001		
-5765	Thamesdown Law Centre		S.1313		
-5763	Thames Valley Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1640	Tewkesbury Borough Council		S.1313		
-1639	Test Valley Borough Council		S.1313		
-1638	Tendring District Council		S.1313		
-5758	Tenby Port		S.1313		
-1637	Tenant Services Authority		S.1311		2012-04-01
-1636	Telford & Wrekin Council		S.1313		
-5756	Telford - (s NTC)		S.1311		
-1635	Teignbridge District Council		S.1313		
-5753	Teeside Development Corporation		S.11001		
-1745	Technology Strategy Board, The		S.1311		
-5750	Teaching as a Career Unit		S.1311		
-5749	Teaching Agency		S.1311		2013-04-01
-5747	Teacher Training Agency (TTA)		S.1311		2005-09-01
-5744	Tayside Regional Council Harbour		S.1313		
-5743	Tayside Enterprise Board		S.1313		
-5742	Tayside Contracts Joint Committee		S.1313		
-5741	Tayside and Central Scotland Transport Partnership (TACTRAN)		S.1313	2005-12-01	
-5740	Tay Road Bridge Joint Board		S.1311	2008-02-01	
-1634	Taunton Deane Borough Council		S.1313		
-5738	Tate Gallery		S.1311		
-5735	Tarbert (Loch Fyne) Harbour		S.11001		2015-12-02
-1633	Tandridge District Council		S.1313		
-1632	Tamworth Borough Council		S.1313		
-1631	Tameside Metropolitan Borough Council		S.1313		
-5731	Tamar Science Park Ltd		S.1313		
-5729	Tamar Bridge and Torpoint Ferry Joint Committee		S.11001	1905-05-14	
-5727	Talklight Ltd		S.1313		
-5726	Talacave Action Group		S.1313		
-5725	Tai Cymru		S.1311		
-5719	Sypta Properties Ltd		S.11001		
-5718	Sypta Ltd		S.11001		
-5713	Swindon Octobus Ltd		S.1313		2009-09-01
-5712	Swindon Centre for Disabled Living		S.1313		
-1630	Swindon Borough Council		S.1313		
-5710	Swansea Action Partnership		S.1313		
-5709	Swansea (Fairwood Common) Aerodrome		S.1313		
-1629	Swale Borough Council		S.1313		
-5704	Sutton Housing Partnership Ltd		S.11001		
-5702	Sustainable Development Education Panel		S.1311		
-5701	Sustainable Development Commission		S.1311		
-1628	Surrey Heath Borough Council		S.1313		
-1627	Surrey County Council		S.1313		
-5697	Sureline Coaches Limited - (s NITHC)		S.11001		1987-07-01
-5696	Supreme Court, the		S.1311	2009-10-01	
-5695	Supreme Court Rule Committee		S.1311		
-5694	Supported Employment Consultative Groups		S.1311		
-5690	Sunderland Port		S.1313		
-5689	Sunderland Empire Theatre Trust Ltd		S.1313		
-5688	Sunderland City Training and Enterprise Council Ltd		S.1311		
-1626	Sunderland City Council		S.1313		
-5687	Sunderland (Unsworth) Aerodrome		S.1313		
-5685	Sullom Voe Port		S.1313		
-5684	Sugar Beet Research and Educational Committee		S.1311		
-1625	Suffolk County Council		S.1313		
-1624	Suffolk Coastal District Council		S.1313		
-5682	Submarine Gift Shop Ltd.		S.11001		
-5681	Studio Schools (en Bloc)		S.1311		
-1766	Student Loans Company Limited		S.1311		
-5680	Student Awards Agency For Scotland		S.1311		
-1623	Stroud District Council		S.1313		
-5677	Stronsay Aerodrome		S.1313		
-5676	Stromness Port		S.1313		
-5675	Strathclyde Passenger Transport Executive - (s PTE)		S.11001		
-5674	Strathclyde Partnership for Transport		S.1313	2007-06-01	
-1622	Stratford-on-Avon District Council		S.1313		
-1754	Strategic Rail Authority (SRA)		S.1311		
-5672	Strategic Investment Board		S.1311		2008-06-01
-5671	Strategic Health Authorities (England) (En Bloc)		S.1311		2013-04-01
-5670	Stranraer Port		S.1313		
-5669	Stranmillis University College (Belfast)		S.1311	1905-04-05	
-5668	Stornoway Port		S.11001		2015-12-02
-5662	Stonehaven Port		S.1313		
-5661	Stonebridge Housing Action Trust		S.1311		
-1621	Stoke-on-Trent City Council		S.1313		
-1620	Stockton-on-Tees Borough Council		S.1313		
-1619	Stockport Metropolitan Borough Council		S.1313		
-5658	Stockport Homes Ltd		S.11001		
-5656	Stirling Enterprise and Economic Development Company Ltd		S.1313		
-5655	Stirling Council		S.1313		
-5654	Stirling Business Centre Ltd		S.1313		
-5653	STFC Innovations Ltd		S.1311	2002-01-01	
-5650	Stevenage Homes Ltd		S.11001		2011-12-01
-1618	Stevenage Borough Council		S.1313		
-5648	Stevenage - (s NTC)		S.1311		
-5644	Steering Committee on Pharmacy Postgraduate Education		S.1311		
-5643	Statute Law Committee for Northern Ireland		S.1311		
-5642	Statute Law Committee		S.1311		
-1617	Statistics Commission		S.1311		
-5641	Statistics Advisory Committee		S.1311		
-5640	State Hospital Management Committee Scotland		S.1311		
-5639	State Hospital Board for Scotland		S.1311		
-5638	Starman (Toiletries) Ltd - (s Remploy Ltd)		S.11001		
-5634	Standing Pharmaceutical Advisory Committee		S.1311		
-5633	Standing Nursing and Midwifery Advisory Committee		S.1311		
-5632	Standing Medical Advisory Committee		S.1311		
-5631	Standing Dental Advisory Committee		S.1311		2010-04-01
-5630	Standing Committee on Postgraduate Medical and Dental Education		S.1311		
-5629	Standing Advisory Committee on Trunk Road Assessment		S.1311		
-5628	Standing Advisory Committee on Industrial Property		S.1311		
-5627	Standing Advisory Commission on Human Rights (NI)		S.1311		
-5626	Standards Commission for Scotland		S.1311		
-1616	Standards Board for England		S.1311		2012-04-01
-1833	Standards & Testing Agency		S.1311	2011-10-01	
-1615	Staffordshire Moorlands District Council		S.1313		
-1614	Staffordshire County Council		S.1313		
-5624	Staffordshire & West Midlands Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1613	Stafford Borough Council		S.1313		
-1802	Staff Commission for Education & Library Boards		S.1311		
-5621	St.Abbs Harbour (Coldingham Shore)		S.11001		2015-12-02
-5619	St. Mary's University College, Belfast		S.1311		2012-09-11
-5618	St. Margaret's Hope Pier (Sth Ronaldsay)		S.11001		2015-12-02
-5617	St. Leger Homes of Doncaster Ltd		S.11001		
-5616	St. Ives Port		S.1313		
-5615	St. Helens Metropolitan Borough Council		S.1313		
-5614	St. George's Community Housing ltd		S.11001		2011-07-01
-1795	St. Edmundsbury Borough Council		S.1313		
-5612	St. Andrews Harbour		S.11001		2015-12-02
-1790	St. Albans City and District Council		S.1313		
-5590	Springfields Fuels Limited		S.11001		
-5587	Sportscotland		S.1311		
-1794	Sports Ground Safety Authority		S.1311		
-5586	Sports Council Trust Company		S.1311		
-5585	Sports Council for Wales National Lottery		S.1311		
-1612	Sports Council for Wales		S.1311		
-1611	Sports Council for Northern Ireland		S.1311		
-5584	Sport on Four Ltd - (s C4)		S.11001		
-1610	Sport England		S.1311		
-5583	Spongiform Encephalopathy Advisory Committee		S.1311		2011-03-01
-5582	Spoliation Advisory Panel		S.1311		
-5578	Spencer (Banbury) Ltd - (s Remploy Ltd)		S.11001		
-1609	Spelthorne Borough Council		S.1313		
-5577	Spectrum Management Advisory Group		S.1311		
-5575	Specialist Procurement Services		S.1311		
-5574	Specialist Advisory Committee on Antimicrobial Resistance		S.1311		
-5573	Special Hospital Services Authority		S.1311		
-5572	Special Health Authorities		S.1311		
-5571	Special European Union Programmes Body		S.1311	1999-12-01	
-5570	Special Education Needs Tribunal (SENT)		S.1311		
-5562	Southport (Birkdale) Aerodrome		S.1313		
-5560	Southern Region Electricity Consumers’ Committee		S.1311		
-5557	Southern Health and Social Care Trust		S.1311	2010-04-01	
-1858	Southern Health and Personal Social Services Board		S.1311		
-5556	Southern Education and Library Board		S.1311		
-5554	Southend-on-Sea Industrial Association Ltd		S.1313		
-1608	Southend-on-Sea Borough Council		S.1313		
-5553	Southend Port		S.1313		
-1607	Southampton City Council		S.1313		
-5550	South Yorkshire Transportation Systems Ltd - (s SYPTE)		S.11001		
-5549	South Yorkshire Supertram Ltd		S.11001		
-5548	South Yorkshire Passenger Transport Executive - (s PTE) trading as Travel South Yorkshire		S.1313	1998-04-01	
-5547	South Yorkshire Passenger Transport Executive - (s PTE)		S.11001		
-5546	South Yorkshire Passenger Transport Authority		S.1313		
-5545	South Yorkshire Metro Ltd - (s SYPTE)		S.11001		
-5544	South Yorkshire Light Rail Ltd - (s SYPTE)		S.11001		
-5542	South Yorkshire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-5541	South Western Region Electricity Consumers’ Committee		S.1311		
-5539	South West Regional Cultural Consortium		S.1311		2010-09-01
-5538	South West of Scotland Transport Partnership (Swestrans)		S.1313	2005-12-01	
-1860	South West of England Development Agency		S.1311		2012-07-01
-5537	South Wales Region Electricity Consumers’ Committee		S.1311		
-5534	South Tyneside Homes Ltd		S.11001		
-1606	South Tyneside Council		S.1313		
-1869	South Staffordshire District Council		S.1313		
-1605	South Somerset District Council		S.1313		
-1604	South Ribble Borough Council		S.1313		
-5530	South Queensferry Port		S.1313		
-1603	South Oxfordshire District Council		S.1313		
-5529	South of Scotland Region Electricity Consumers’ Committee		S.1311		
-1602	South Northamptonshire Council		S.1313		
-1601	South Norfolk District Council		S.1313		
-1841	South Lanarkshire Council		S.1313		
-1600	South Lakeland District Council		S.1313		
-1599	South Kesteven District Council		S.1313		
-1598	South Holland District Council		S.1313		
-1597	South Hams District Council		S.1313		
-1596	South Gloucestershire Council		S.1313		
-5524	South Essex Homes Ltd		S.11001		
-5523	South Eastern Trains Ltd		S.11001		
-5522	South Eastern Region Electricity Consumers’ Committee		S.1311		
-5521	South Eastern Health and Social Care Trust		S.1311	2010-04-01	
-1595	South Eastern Education and Library Board		S.1311		
-5520	South East of Scotland Transport Partnership (SESTRAN)		S.1313	2005-12-01	
-1594	South East England Development Agency		S.1311		2012-07-01
-5519	South East England Cultural Consortium		S.1311		2010-09-01
-1593	South Downs National Park Authority		S.1313	2010-04-01	
-1592	South Derbyshire District Council		S.1313		
-1591	South Cambridgeshire District Council		S.1313		
-5515	South Buckinghamshire District Council		S.1313		
-1855	South Ayrshire Council		S.1313		
-1590	Somerset County Council		S.1313		
-5509	Somerset Careers Ltd		S.1313		
-1589	Solihull Metropolitan Borough Council		S.1313		
-5506	Solihull community Housing Ltd		S.11001		
-5499	Social Services Inspectorate for Wales Advisory Group (WO)		S.1311		
-5498	Social Security Information Technology Services Agency		S.1311		
-5497	Social Security Appeal Tribunals		S.1311		
-1774	Social Security Agency (Northern Ireland)		S.1311		
-1588	Social Security Advisory Committee		S.1311		
-1867	Social Science Research Council		S.1311		
-5496	Social Fund		S.1311		
-5495	Social Care and Social Work Improvement Scotland (t/a Care Inspectorate)		S.1311	2010-04-01	
-5494	Snowdonia National Park Authority		S.1313	2005-11-01	
-5491	Small Business Service		S.1311		
-1587	Slough Borough Council		S.1313		
-5487	Skipton Fund Ltd		S.1311		
-5485	Skills Task Force		S.1311		
-1586	Skills Funding Agency		S.1311		
-5484	Skills Development Scotland Co. Limited (t/a Skills Development Scotland) (The)		S.1311		
-5483	Skerray Harbour		S.11001		2015-12-02
-5482	Skelmersdale - (s NTC)		S.1311		
-5481	Sixth Form College Corporations (England)		S.1313		2012-04-01
-5478	SITPRO Limited (Simpler Trade Procedures Board)		S.1311		
-1786	Sir John Soane’s Museum		S.1311		
-1741	Single Source Regulations Office (SSRO)		S.1311		
-5469	Sianel Pedwar Cymru (S4C) (Welsh Fourth Channel Authority)		S.1311		
-5468	Shropshire Towns and Rural Housing Ltd		S.11001	2013-04-01	
-1585	Shropshire Council		S.1313		
-5461	Shoreham Port Authority		S.11001		
-5460	Shoreham Aerodrome		S.1313		
-5457	Ship Support Agency		S.1311		
-5454	Shetland Leasing and Property Developments Ltd		S.11001		
-1584	Shetland Islands Council		S.1313		
-5453	Shetland Heat energy and Power Ltd		S.11001		
-5452	Shetland Charitable Trust		S.1313		
-1583	Shepway District Council		S.1313		
-5445	Sheffield Homes Ltd		S.11001		2013-04-01
-5444	Sheffield Development Corporation		S.11001		
-1582	Sheffield City Council		S.1313		
-5442	Sharpness (Gloucester) - (s BWB)		S.11001		
-5441	Shared Services Connect Limited (SSC)		S.11001	2013-11-01	
-1581	Sevenoaks District Council		S.1313		
-1580	Service Personnel and Veterans Agency		S.1311		2011-06-01
-1780	Service Children’s Education		S.1311		2013-03-01
-1747	Serious Organised Crime Agency (SOCA)		S.1311		2013-10-01
-1579	Serious Fraud Office		S.1311		
-5427	Sentencing Advisory Panel		S.1311		
-1578	Senior Salaries Review Body		S.1311		
-5423	Sellafield Ltd		S.11001		
-1577	Selby District Council		S.1313		
-5422	Seirbheis nam Meadhanan Gàidhlig (MG Alba)		S.1311	1905-06-12	
-1576	Sefton Metropolitan Borough Council		S.1313		
-1575	Sedgemoor District Council		S.1313		
-1574	Security Vetting Appeals Panel		S.1311		
-5421	Security Service Tribunal		S.1311		
-1573	Security Industry Authority		S.1311		
-5420	Security Facilities Executive		S.1311		
-5419	Security Commission		S.1311		2010-10-01
-5418	Security and Intelligence Services		S.1311		
-5417	Sector Skills Development Agency		S.1311		
-5416	Section 706 Tribunal		S.1311		
-5415	Secretary of State's Salmon Task Force		S.1311		
-5414	Secretary of State's Advisory Panel of Economic Consultants		S.1311		1905-06-21
-5413	Secretary of State's Advisory Group on Sustainable Development		S.1311		
-5412	Secretary of State's Advisory Committee on Scotland’s Travelling People		S.1311		1905-06-21
-5411	Secretary of State's (Electricity) Fisheries Committee (a.k.a. Fisheries Electricity Committee)		S.1311		
-5410	Secretary of State for Scotland's Advisory Group on Sustainable Development		S.1311		
-5407	Sea Fisheries Committees		S.1313		2011-03-01
-1572	Sea Fish Industry Authority		S.1311		
-5406	Scrabster Harbour		S.11001		2015-12-02
-5405	Scottish Widows Bank plc		S.12201		2014-03-01
-5404	Scottish Water Solutions		S.11001		
-5403	Scottish Water and Sewerage Customers Council		S.1311		
-5402	Scottish Water		S.11001		
-5401	Scottish Vocational and Education Council		S.1311		
-5399	Scottish Valuation and Rating Council		S.1311		1905-06-24
-5398	Scottish University for Industry (trading as Learn Direct Scotland)		S.1311		
-5397	Scottish Studentship Selection Committee		S.1311		
-5396	Scottish Standing Committee for the Calculation of Residual Values of Fertilisers and Feeding stuffs		S.1311		1905-06-24
-1571	Scottish Sports Council		S.1311		
-5395	Scottish Social Services Council		S.1311		
-1570	Scottish Screen		S.1311		2010-07-01
-5394	Scottish River Purification Boards		S.1313		1995-10-01
-5393	Scottish Regional Transport Partnerships (En Bloc)		S.1313	2005-12-01	
-5392	Scottish Records Advisory Council		S.1311		2011-04-01
-5391	Scottish Record Office		S.1311		
-5390	Scottish Qualifications Authority		S.1311		
-5389	Scottish Public Services Ombudsman		S.1311		
-5388	Scottish Public Pensions Agency		S.1311		
-5387	Scottish Prison Service		S.1311		
-5386	Scottish Policing Authority		S.1311	2013-04-01	
-5385	Scottish Police Services Authority		S.1311		2013-04-01
-5384	Scottish Parliamentary Corporate Body		S.1311		
-5383	Scottish Office Pensions Agency		S.1311		
-5382	Scottish Natural Heritage		S.1311		
-5381	Scottish Medical Practices Committee		S.1311		
-5380	Scottish Legal Complaints Commission		S.1311		
-5379	Scottish Legal Aid Board		S.1311		
-1569	Scottish Law Commission		S.1311		
-5378	Scottish Joint Industry Board		S.1311		
-5377	Scottish Information Commissioner		S.1311		
-5376	Scottish Industrial Development Advisory Board		S.1311		2011-04-01
-5375	Scottish Human Rights Commission		S.1311		
-5374	Scottish Housing Regulator		S.1311	2011-04-01	
-1568	Scottish Hospital Trust		S.1311		
-5373	Scottish Hospital Endowments Research Trust		S.1311		1905-06-24
-5372	Scottish Homes Residuary Body		S.1311		1905-06-24
-5371	Scottish Homes		S.11001		
-5370	Scottish Higher Education Funding Council		S.1311		
-1567	Scottish Government		S.1311		
-5369	Scottish Futures Trust Ltd		S.1311	2008-09-01	
-5368	Scottish Further Education Unit		S.1311		
-5367	Scottish Further Education Funding Council		S.1311		
-5366	Scottish Further & Higher Education Funding Council (Scottish Funding Council)		S.1311		
-5365	Scottish Fisheries Protection Agency		S.1311		2009-04-01
-5364	Scottish Fire and Rescue Service		S.1311	2013-04-01	
-5363	Scottish Film Council		S.1311		
-5362	Scottish Examination Board		S.1311		
-5361	Scottish Environment Protection Agency		S.1311		
-5360	Scottish Enterprise		S.1311		
-5359	Scottish Education Department		S.1311		
-5358	Scottish Economic Council		S.1311		
-5357	Scottish Development Agency		S.1311		
-5356	Scottish Crop Research Institute		S.1311		1905-06-24
-5355	Scottish Criminal Cases Review Commission		S.1311		
-5354	Scottish Crime Prevention Council		S.1311		
-5353	Scottish Courts (En Bloc)		S.1311		
-5352	Scottish Council for Research in Education		S.1311		
-5351	Scottish Council for Post-Graduate Medical Education and Dental Education		S.1311		1905-06-24
-5350	Scottish Council for Educational Technology		S.1311		
-5349	Scottish Conveyancing and Executry Services Board		S.1311		
-5348	Scottish Consumer Council		S.1311		
-5347	Scottish Consultative Council on the Curriculum		S.1311		
-5346	Scottish Consolidated Fund		S.1311		
-5345	Scottish Commission for the Regulation of Care		S.1311		2011-04-01
-5344	Scottish Children's Reporter Administration		S.1311		
-5343	Scottish Child-Care Board		S.1311		
-5342	Scottish Canals		S.1311	2012-07-01	
-1845	Scottish Borders Council		S.1313		
-5340	Scottish Association of Citizens Advice Bureau (The)		S.1311	2005-04-01	
-1566	Scottish Arts Council		S.1311		2010-07-01
-5339	Scottish Ambulance Service Board		S.1311		
-5338	Scottish Agricultural Wages Board		S.1311		
-5337	Scottish Agricultural Consultative Panel		S.1311		
-5336	Scottish Agricultural College		S.1311		
-5335	Scottish Advisory Committee on the Medical Workforce		S.1311		1905-06-24
-5334	Scottish Advisory Committee on Telecommunications		S.1311		2003-12-29
-5333	Scottish Advisory Committee on Drug Misuse		S.1311		1905-06-24
-5332	Scottish Advisory Committee on Distinction Awards		S.1311		
-5331	Scotland's Commissioner for Children and Young People		S.1311		
-1565	Scotland Office		S.1311		
-5330	SCMG Enterprises Ltd		S.11001	1987-11-01	
-5329	Scientific Committee on Tobacco and Health		S.1311		
-5328	Scientific Advisory Committee on Nutrition		S.1311		
-1564	Science Museum Group		S.1311	2012-04-01	
-1563	Science and Technology Facilities Council		S.1311		
-1799	Science Advisory Committee on the Medical Implications of Less-Lethal Weapons		S.1311	2009-07-01	
-1779	School Teachers’ Review Body		S.1311		
-5327	School Support Staff Negotiating Body		S.1311		2012-02-01
-1562	School Food Trust		S.1311		2011-09-01
-5326	School Examinations and Assessment Council		S.1311		
-5325	Scarborough Port		S.1313		
-1561	Scarborough Borough Council		S.1313		
-5323	Saundersfoot Harbour Commissioners		S.11001		
-5322	Satman Developments		S.1313		
-5320	Sandwich Port and Haven Commissioners		S.11001		
-5319	Sandwell Tenants and Residents Federation Ltd		S.1313		
-1560	Sandwell Metropolitan Borough Council		S.1313		
-5318	Sandwell Homes Ltd		S.11001		2013-01-01
-5317	Sandwell Homeless and Resettlement Project Ltd		S.1313		
-5314	Sanday Port		S.1313		
-5313	Sanday Aerodrome		S.1313		
-5305	Saltcoats Port		S.1313		
-5304	Salmon Advisory Council		S.1311		
-5303	Salix Homes Ltd		S.11001		
-1559	Salford City Council		S.1313		
-5300	Salcombe Port		S.1313		
-5295	Safefood (Food Safety Promotion Board)		S.1311	1999-12-01	
-1801	S4C2 Cyf. (S - S4C)		S.11001		
-5292	S4C Rhyngwladol Cyf. (S - S4C)		S.11001		
-5291	S4C Masnachol Cyf - (s S4C)		S.11001		
-5290	S.M.N.E Ltd.		S.11001		
-5289	S.A.D.A.C.C.A. Ltd (Sheffield and District Afro-Caribbean Community Association Ltd)		S.1313		
-5288	Rykneld Homes Ltd		S.11001		
-1558	Ryedale District Council		S.1313		
-5286	Rye Harbour Commissioners		S.11001		
-5285	Ryde Port		S.1313		
-1557	Rutland County Council		S.1313		
-1556	Rushmoor Borough Council		S.1313		
-1555	Rushcliffe Borough Council		S.1313		
-1554	Rural Payments Agency		S.1311		
-5277	Rural Development Commission		S.1311		
-1553	Runnymede Borough Council		S.1313		
-5276	Runcorn - (s NTC)		S.1311		
-1552	Rugby Borough Council		S.1313		
-5273	Royal Ulster Constabulary George Cross Foundation		S.1311		
-5272	Royal Ulster Constabulary		S.1311		
-5271	Royal Patriotic Fund		S.1311		
-5270	Royal Parks Agency		S.1311		
-5269	Royal Observatory Greenwich		S.1311		
-1822	Royal Naval Submarine Museum		S.1311		
-5268	Royal Naval Museum Trading Company Ltd.		S.11001		
-5267	Royal Naval Museum		S.1311		
-1782	Royal Mint Advisory Committee on the Design of Coins, Medals, Seals and Decorations		S.1311		
-1551	Royal Mint		S.11001		
-5266	Royal Military College of Science Advisory Council (RCMS)		S.1311		2004-04-01
-1550	Royal Marines Museum		S.1311		
-5265	Royal Mail Plc (and subsidiaries)		S.11001		2013-10-01
-5264	Royal Household		S.1311		
-5263	Royal Hospital Chelsea		S.1311		
-5262	Royal Fine Art Commission for Scotland		S.1311		
-5261	Royal Fine Art Commission		S.1311		1905-06-26
-5260	Royal Docks Management Authority Ltd - (s LDA)		S.11001	2002-04-01	
-5259	Royal Commission on the Ancient and Historical Monuments of Wales		S.1311		
-5258	Royal Commission on Long Term Care of the Elderly		S.1311		
-5257	Royal Commission on Historical Monuments in England		S.1311		
-1549	Royal Commission on Environmental Pollution		S.1311		
-5256	Royal Commission on Ancient and Historical Monuments of Scotland		S.1311		2015-04-01
-5255	Royal Collection Trust		S.11001		
-5254	Royal Collection Enterprises Ltd		S.11001		
-5253	Royal Botanic Gardens, Kew		S.1311		
-5252	Royal Botanic Garden, Edinburgh		S.1311		
-1548	Royal Borough of Windsor and Maidenhead		S.1313		
-1547	Royal Borough of Kingston upon Thames		S.1313		
-1546	Royal Borough of Kensington and Chelsea		S.1313		
-1545	Royal Borough of Greenwich		S.1313		
-5251	Royal Bank of Scotland plc, The		S.12201		
-5250	Royal Bank of Scotland Group plc Subsidiaries		S.12201		
-5249	Royal Bank of Scotland Group plc		S.12501		
-1544	Royal Armouries Museum		S.1311		
-1543	Royal Air Force Museum		S.1311		
-5246	Rowett Research Institute		S.1311		
-5245	Routes to Work South		S.1313		
-1542	Rotherham Metropolitan Borough Council		S.1313		
-1541	Rother District Council		S.1313		
-5242	Rossendale Transport Ltd		S.11001		
-1540	Rossendale Borough Council		S.1313		
-5238	Rosehearty Harbour		S.11001		2015-12-02
-5233	Rolls Royce PLC		S.11001		
-1539	Rochford District Council		S.1313		
-1538	Rochdale Metropolitan Borough Council		S.1313		
-1862	Roads Service (Northern Ireland)		S.1311		
-5222	RNM Functions Ltd		S.11001		
-5221	RM Museum Ltd		S.11001		
-5217	Riverside Centre Ltd, The		S.1313		
-5216	Rivers Agency (Northern Ireland)		S.1311		
-5215	River Yealm Harbour Authority		S.11001		
-5214	River Nith Navigation		S.11001		2015-12-02
-5210	Ringway Handling Services Ltd (s MA)		S.11001/3	2013-02-01	
-5209	Ringway Handling Limited (s MA)		S.11001/3	2013-02-01	
-5208	Ringway Developments Ltd		S.1313		
-1537	Richmondshire District Council		S.1313		
-1536	Ribble Valley Borough Council		S.1313		
-1784	Rhondda Cynon Taff County Borough Council		S.1313		
-1809	Reviewing Committee on the Export of Works of Art		S.1311		
-1535	Review Board for Government Contracts		S.1311		
-5197	Revenue Scotland		S.1311	2015-01-01	
-1534	Revenue and Customs Prosecutions Office		S.1311		2010-01-01
-5193	Resource: The Council for Museums Archives and Libraries		S.1311		2004-04-01
-5192	Residuary Body for Wales		S.1311		
-5191	Residuary Bodies		S.1313		
-5189	Research Sites Restoration Limited		S.1311	2009-02-01	
-5188	Research Councils (En Bloc)		S.1311		
-5187	Rent Service (The)		S.1311		2009-04-01
-5186	Rent Assessment Panels (Wales)		S.1311		
-5185	Rent Assessment Panels (Scotland)		S.1311		
-5184	Rent Assessment Panels (RAPS)		S.1311		2013-07-01
-5183	Rent Assessment Panels (Northern Ireland)		S.1311		
-1873	Renfrewshire Council		S.1313		
-5182	Renfrew Port		S.1313		
-1533	Renewable Fuels Agency		S.1311		
-5181	Renewable Energy Advisory Committee		S.1311		1905-06-23
-1532	Reigate and Banstead Borough Council		S.1313		
-5178	Registry of Friendly Societies		S.1311		
-5177	Registrar of the Public Lending Right		S.1311		2013-10-01
-5176	Registrar of Occupational and Personal Pension Schemes		S.1311		
-5175	Registers of Scotland		S.11001		
-5863	Registered Social Landlords (RSLs) in Wales		S.11001	1996-07-24	
-5862	Registered Social Landlords (RSL) in Scotland		S.11001	2001-07-18	
-5174	Registered Nursery Education Inspectors Appeals Tribunal		S.1311		
-5173	Registered Inspectors of Schools Appeals Tribunal (Wales)		S.1311		
-5172	Registered Inspectors of Schools Appeals Tribunal		S.1311		
-5861	Registered Housing Associations (RHAs) in Northern Ireland		S.11001	1992-07-15	
-5171	Registered Homes Tribunals		S.1311		
-5170	Registered Homes Tribunal (Northern Ireland)		S.1311		
-5169	Regional Panels in MAFF		S.1311		
-5168	Regional Industrial Development Boards		S.1311		
-5167	Regional Health Authorities (En Bloc)		S.1311		1996-04-01
-5166	Regional Health and Social Care Board (Northern Ireland)		S.1311	2009-04-01	
-5165	Regional Health and Social Care Board		S.1311		
-5164	Regional Flood Defence Committees		S.1311		
-5163	Regional Business Services Organisation (Northern Ireland)		S.1311	2009-04-01	
-5162	Regional Business Services Organisation		S.1311		
-5161	Regional Assemblies (England)		S.1313		
-5160	Regional Aggregation Bodies		S.1311		
-5159	Regional Agency for Public Health and Social Well-being (Northern Ireland), The		S.1311	2009-04-01	
-5156	Reedmonte Ltd		S.1313		
-1531	Redditch Borough Council		S.1313		
-5150	Redditch - (s NTC)		S.1311		
-1875	Redcar and Cleveland Council		S.1313		
-5149	Redbridge Homes Ltd		S.11001		2012-08-01
-5144	Reading Transport Ltd		S.11001		
-1530	Reading Borough Council		S.1313		
-5143	Reactor Sites Management Company Ltd.		S.11001		
-5141	RCUK Shared Services Centre Ltd		S.1311	2007-08-01	
-5136	Rathgael & White Abbey Schools Management Board		S.1311		
-5135	Rate Collection Agency (Northern Ireland)		S.1311		
-5134	Ramsgate Port		S.1313		
-5132	Rampton Hospital Authority		S.1311		
-5131	RAJAR (Radio Joint Audience Research) Ltd (50%) (sBBCW) (Associate)		S.11001		
-5129	Railsale Ltd		S.1311		
-5128	Rail Users’ Consultative Committees		S.1311		
-5127	Rail Passengers' Council		S.1311		
-5126	Rail Passengers' Committees		S.1311		
-5125	Rail for London Ltd		S.11001	2011-04-01	
-5124	RAF Training Group Defence Agency		S.1311		2006-04-01
-5123	RAF Signals Engineering Establishment		S.1311		
-5122	RAF Personnel Management Agency		S.1311		2004-04-01
-5121	RAF Maintenance Group Defence Agency		S.1311		
-5120	RAF Logistics Support Services		S.1311		
-5119	Radiocommunications Agency		S.1311		
-1756	Radioactive Waste Management Limited		S.1311	2014-04-01	
-5118	Radioactive Waste Management Advisory Committee		S.1311		
-5117	Radio Authority		S.1311		
-5113	Race Relations Forum		S.1311		
-5112	Race Relations Employment Advisory Group		S.1311		
-5111	Race Education and Employment Forum		S.1311		
-5108	Queen Victoria School (Charity)		S.1311	2006-04-01	
-5107	Queen Victoria School		S.1311		2005-04-01
-1529	Queen Elizabeth II Conference Centre		S.11001		
-5106	Quality Space (Stirling) Ltd		S.1313		
-5105	Quality Meat Scotland		S.1311	2008-04-01	
-5104	Qualifications, Curriculum and Assessment Authority for Wales		S.1311		2006-04-01
-1528	Qualifications and Curriculum Development Agency		S.1311		2012-04-01
-5102	QinetiQ		S.11001		
-1527	Purbeck District Council		S.1313		
-5099	Public Trust Office		S.1311		
-5098	Public Services Productivity Panel Unit		S.1311		2002-05-01
-5097	Public Services Ombudsman for Wales		S.1311		
-5096	Public Service Training Council Northern Ireland		S.1311		
-5095	Public Service Commission		S.1311	2006-03-01	
-5094	Public Records Office of Northern Ireland		S.1311		
-5093	Public Record Office		S.1311		
-1526	Public Prosecution Service for Northern Ireland		S.1311	2005-06-01	
-5092	Public Private Partnerships Programme Ltd (4ps)		S.1313	2009-08-01	
-1866	Public Lending Right and the Public Lending Right Advisory Committee		S.1311		1905-07-01
-1770	Public Health Wales NHS Trust		S.1311	2009-08-01	
-1525	Public Health Laboratory Service Board		S.1311		2005-04-01
-1524	Public Health England		S.1311	2013-04-01	
-5091	Public Guardianship Office		S.1311		2007-10-01
-5090	Public Guardian Board		S.1311		2012-09-01
-5089	Prudential Regulation Authority		S.12601	2013-04-01	
-5086	Proudman Oceanographic Laboratory		S.1311		
-5085	Proteus Theatre Co Ltd		S.1313		
-5082	Property Advisory Group		S.1311		2003-07-01
-5081	Property Advisors to the Civil Estate (PACE)		S.1311		
-5076	Probation Trusts		S.1311		
-1523	Probation Board for Northern Ireland		S.1311		
-1522	Privy Council Office		S.1311		
-5860	Private registered providers (PRPs) of social housing in England		S.11001	1996-07-24	
-5075	Priority Sites Ltd		S.11001	2008-09-01	
-5071	Primary Care Trusts (En Bloc)		S.1311		2013-04-01
-5070	Prestwick Aviation Holdings Limited		S.1311	2013-11-22	
-5069	Prestwick Airport Property Limited		S.11001	2013-11-22	
-5068	Prestwick Airport Limited		S.11001	2013-11-22	
-5067	Prestwick Airport Infrastructure Limited		S.11001	2013-11-22	
-1521	Preston City Council		S.1313		
-1520	Prescription Pricing Authority		S.1311		2006-04-01
-5065	PPP Arbiter		S.1313		2010-10-01
-5063	Powys Teaching Health Board		S.1311	2006-06-01	
-1519	Powys County Council		S.1313		
-5061	Potteries Box Company Ltd - (s Remploy Ltd) (The)		S.11001		
-5060	Potato Industry Development Council		S.1311		
-5059	Potato Council Ltd		S.1311		
-5058	PostCap (Guernsey) Ltd. (Guernsey) - (s C)		S.11001		
-5057	Postal Services Holding Company Plc.		S.1311	2000-09-01	
-5056	Postal Services Holding Company Plc		S.11001		2012-04-01
-1518	Postal Services Commission		S.1311		
-5055	Post Qualification Education Board for Health Science Pharmacists in Scotland		S.1311		
-5054	Post Office Users' National Council		S.1311		
-5053	Post Office Users' Council for Wales		S.1311		
-5052	Post Office Users' Council for Scotland		S.1311		
-5051	Post Office Users' Council for Northern Ireland		S.1311		
-5050	Post Office Limited		S.11001	1905-06-09	
-5049	Positive Lifestyles Ltd		S.1313		
-5047	Portsmouth Port		S.1313		
-1517	Portsmouth City Council		S.1313		
-5045	Portree (Port)		S.1313		
-5040	Port Seton Harbour		S.11001		2015-12-02
-5039	Port of Tyne Authority		S.11001		
-5038	Port of London Authority		S.11001		
-5036	Port Nahaven (Islay)		S.1313		
-5035	Port Isaac		S.11001		
-5032	Poole Housing Partnership Ltd		S.11001		
-5031	Poole Harbour Commissioners		S.11001		
-5027	Policyholders' Protection Board		S.1311		2001-11-30
-5026	Police Service of Scotland		S.1311	2013-04-01	
-1516	Police Service of Northern Ireland		S.1311		
-5025	Police Rehabilitation and Retraining Trust		S.1311	1905-06-21	
-5024	Police Ombudsman for Northern Ireland (Independent Commission for Police Complaints for Northern Ireland)		S.1311		
-1515	Police Negotiating Board		S.1311		
-1728	Police Information Technology Organisation (PITO)		S.1311		
-5023	Police Forces (Scotland) (En Bloc)		S.1313		
-5022	Police Forces (En Bloc)		S.1313		
-1514	Police Discipline Appeals Tribunal		S.1311		
-1513	Police Complaints Authority		S.1311		
-5021	Police Authority for Northern Ireland		S.1311		
-5020	Police Authorities (En Bloc)		S.1313		2012-11-01
-1512	Police Arbitration Tribunal		S.1311		
-5019	Police and Crime Commissioners (En bloc)		S.1313	2012-11-01	
-5018	Police Advisory Board for Scotland		S.1311		
-1511	Police Advisory Board for England and Wales		S.1311		
-5017	Poisons Board (Northern Ireland)		S.1311		
-5016	Poisons Board		S.1311		
-5015	Pointsforlife Ltd		S.1311	2009-07-01	
-5013	Pneumoconiosis Workers Compensation Board		S.1311		
-5012	Plymouth Marines Application Ltd		S.11001		
-5011	Plymouth Marine Laboratory		S.1311		
-5010	Plymouth Development Corporation		S.11001		
-1510	Plymouth City Council		S.1313		
-5008	Plymouth City Bus Ltd		S.11001		2009-12-01
-5006	Plymouth (Roborough) Aerodrome		S.1313		
-1509	Plant Varieties and Seeds Tribunal		S.1311		
-4999	Planning Service (Northern Ireland)		S.1311		2011-04-01
-1508	Planning Inspectorate		S.1311		
-4998	Planning Appeals Commission		S.1311		
-4994	Place Names Advisory Committee		S.1311		
-4993	Pittenweem Port		S.1313		
-4992	Pirbright Institute		S.1311		2013-12-01
-4982	Pig Production Development Committee		S.1311		
-4979	PhonepayPlus		S.1311	2007-12-01	
-4975	Phillips Port (Caithness)		S.1313		
-4974	Pharmacists’ Review Panel		S.1311		
-4972	Peterlee - (s NTC)		S.1311		
-4971	Peterhead Port		S.11001		2015-12-02
-1507	Peterborough City Council		S.1313		
-4970	Peterborough - (s NTC)		S.1311		
-4967	Pesticides Residue Committee		S.1311		
-4966	Perth Port		S.1313		
-1840	Perth and Kinross Council		S.1313		
-4965	Persons Hearing Estate Agents Appeal		S.1311		
-4964	Persons Hearing Consumer Credit Licensing Appeals		S.1311		
-1506	Personal Accounts Delivery Authority		S.1311		2008-04-01
-4961	People's Panel Advisory Group		S.1311		
-1505	People, Pay and Pensions Agency		S.1311		2011-07-01
-4959	People and Arts (Latin Am) LLC [USA] (50%) (sBBCW) (Associate)		S.11001		
-4958	Penzance Port		S.1313		
-4956	Pensions Regulator, The		S.1311		
-4955	Pensions Ombudsman, The		S.1311		
-4954	Pensions Compensation Board		S.1311		
-4953	Pensions Appeal Tribunal for Scotland		S.1311		1905-06-24
-4952	Pensions Appeal Tribunal		S.1311		
-4951	Pensions Advisory Service, The		S.1311		
-1504	Pension, Disability and Carers Service		S.1311	2008-03-01	
-1503	Pension Protection Fund		S.12801		
-4950	Penryn Port		S.1313		
-4948	Pennan Harbour		S.11001		2015-12-02
-1502	Pendle Borough Council		S.1313		
-1501	Pembrokeshire County Council		S.1313		
-4942	Pembrokeshire Coast National Park Authority		S.1313	1995-11-01	
-1500	Peak District National Park Authority		S.1313	1996-06-01	
-4932	Patient Client Council (Northern Ireland)		S.1311	2009-04-01	
-4931	Patient Client Council		S.1311		
-4929	Patent Office (t/a The UK Intellectual Property Office)		S.11001		
-4928	Passenger Transport Executives (PTE)		S.1313	1998-04-01	
-4927	Passenger Transport Executive Group Ltd (PTEG Ltd)		S.1311	2006-06-01	
-4926	Passenger Transport Authorities (En Bloc)		S.1313		2009-02-01
-4923	Partnerships UK		S.11001		
-4922	Partnerships for Schools		S.1311		2012-06-01
-4921	Partnerships for Church of England Schools		S.1311		2006-12-01
-4920	Partnership Fund Assessment Panel		S.1311		
-1727	Particle Physics and Astronomy Research Council (PPARC)		S.1311		
-4916	Parole Board for Scotland		S.1311		
-4915	Parole Board for England and Wales		S.1311		
-4914	Parliamentary Boundary Commission for Wales		S.1311		
-4913	Parliamentary Boundary Commission for England		S.1311		
-1814	Parliamentary and Health Service Ombudsman		S.1311		
-4908	Parish Councils (England)		S.1313		
-4907	Parcelforce Worldwide - (s C)		S.11001		
-4900	Parades Commission		S.1311		
-4898	Papa Westray Aerodrome		S.1313		
-4894	Paignton Port		S.1313		
-4891	Pacific Nuclear Transport Limited (s. BNG / BNFL)		S.11001		
-1499	Oxfordshire County Council		S.1313		
-1498	Oxford City Council		S.1313		
-4888	Overseas Service Pensions Scheme Advisory Board		S.1311		2006-02-01
-4887	Overseas Project Board		S.1311		
-4883	Osel Enterprises Ltd		S.1313		
-1497	Orkney Islands Council		S.1313		
-4879	Orkney Harbour Commissioners		S.1313		
-4875	Orford Town Trustees		S.11001		
-1496	Ordnance Survey of Northern Ireland		S.1311		
-1495	Ordnance Survey		S.11001		
-1832	One NorthEast		S.1311		2012-07-01
-4859	Olympic Park Legacy Company		S.1313		2012-04-01
-4858	Olympic Lottery Distributor		S.1311		2013-04-01
-1494	Olympic Delivery Authority		S.1311		2014-12-02
-1493	Oldham Metropolitan Borough Council		S.1313		
-4857	Oldham Economic Development Association Ltd		S.1313		
-4856	Oldham Coliseum Theatre Ltd, The		S.1313		
-1844	Oil and Pipelines Agency		S.11001		
-3601	Oil and Gas Projects and Supplies Office Board		S.1311		
-1879	OGC buying.solutions		S.11001		
-3599	OFWAT National Customer Council		S.1311		
-3598	Offshore Industry Liaison Committee		S.1311		
-3597	Offshore Energy Technology Board		S.1311		
-3596	Office of Water Services (OFWAT)		S.1311		
-1492		government-organisation:D24	S.1311		
-3595	Office of the Scottish Parliamentary Standards Commissioner		S.1311		2011-04-01
-3594	Office of the Scottish Charity Regulator (OSCR)		S.1311	2003-12-01	
-3593	Office of the Rail Regulator and International Rail Regulator (ORR)		S.1311		
-1818	Office of the Paymaster General		S.1311		
-1829	Office of the Parliamentary Commissioner and Health Service Commissioners		S.1311		
-3592	Office of the Northern Ireland Commissioner for Complaints		S.1311		
-3591	Office of the Northern Ireland Commissioner for Administration		S.1311		
-3590	Office of the Information Commissioner		S.1311		
-1491	Office of the Immigration Services Commissioner		S.1311		
-3589	Office of the Deputy Prime Minister (ODPM)		S.1311		
-1490	Office of the Data Protection Registrar		S.1311		
-3588	Office of the Data Protection Commissioner		S.1311		
-3587	Office of the Commissioner for Public Appointments in Scotland		S.1311		2011-04-01
-3586	Office of the Commissioner for Public Appointments		S.1311		
-1489	Office of the Children's Commissioner		S.1311		
-3585	Office of the Chief Investigating Officer (Scotland)		S.1311		2011-04-01
-3584	Office of the Adjudicator - Broadcast Transmission Services		S.1311	2008-09-01	
-1755	Office of Telecommunications (OFTEL)		S.1311		
-1488	Office of Surveillance Commissioners		S.1311		
-1750	Office of Rail Regulation (ORR)		S.1311		
-3583	Office of Qualifications and Examinations Regulator (Ofqual)		S.1311		
-3582	Office of Public Services and Science (OPSS)		S.1311		
-3581	Office of Public Service		S.1311		
-3580	Office of Passenger Rail Franchising		S.1311		
-3578	Office of Her Majesty’s Chief Inspector of Education and Training in Wales (Estyn)		S.1311		
-3579	Office of Her Majesty's Chief Inspector of Schools in England		S.1311		
-1878	Office of Health Professionals Adjudicators		S.1311		2012-07-01
-3577	Office of Government Commerce		S.1311		
-3576	Office of Gas Supply		S.1311		
-3575	Office of Gas and Electricity Markets (OFGEM)		S.1311		
-1487	Office of Fair Trading		S.1311		
-3574	Office of Electricity Regulation		S.1311		
-3573	Office of Communications (Ofcom)		S.1311	1905-06-24	
-3572	Office for the Regulation of Electricity and Gas (OFREG) (Northern Ireland)		S.1311		2007-04-01
-3571	Office for Standard in Education children's Services and Skills (Ofsted)		S.1311		
-1743	Office for Nuclear Regulation (ONR)		S.11001	2014-03-01	
-1486	Office for National Statistics		S.1311		
-3570	Office for Legal Complaints		S.1311		
-3569	Office for Judicial Complaints		S.1311	2006-04-01	
-1485	Office for Fair Access		S.1311		
-1484	Office for Budget Responsibility		S.1311	2011-03-01	
-3562	Occupational Pensions Regulatory Authority (OPRA)		S.1311		
-3561	Occupational Pensions Board		S.1311		
-3560	OBRIC Publications Ltd - (s LDDC)		S.11001		
-3559	Oban Port		S.1313		
-3553	Oadby and Wigston District Council		S.1313		
-3552	Nursing and Midwifery Council, The		S.1311	2002-01-01	
-3550	Nurses', Midwives' and other NHS Professions Review Body		S.1311		
-3551	Nurses, Midwives, Health Visitors and Professions Allied to Medicine Pay Review Body		S.1311		
-3549	Nursery Channel Ltd. (S - S4C) (The)		S.11001		
-3548	Nuneaton and Bedworth Leisure Trust		S.1313		
-1483	Nuneaton and Bedworth Borough Council		S.1313		
-3547	Nuclear Weapons Safety Committee		S.1311		
-3546	Nuclear Transport Limited (s. BNG / BNFL)		S.11001		
-1482	Nuclear Research Advisory Council		S.1311	1905-06-24	
-3545	Nuclear Powered Warships Safety Committee		S.1311		
-3544	Nuclear Liabilities Fund Trust Company		S.1311		
-3543	Nuclear Generation Decommissioning Fund Ltd		S.11001		
-3542	Nuclear Flask Hire Limited (s. BNG / BNFL)		S.11001		
-1481	Nuclear Decommissioning Authority		S.1311		
-1480	NS&I		S.1311		
-3539	NPL Management Limited		S.11001	2015-01-01	
-1479	Nottinghamshire County Council		S.1313		
-3535	Nottingham City Transport Co Ltd		S.11001		
-3534	Nottingham City Homes Ltd		S.11001		
-1478	Nottingham City Council		S.1313		
-3530	Norwich Port		S.1313		
-1477	Norwich City Council		S.1313		
-3527	Norwich Airport Ltd		S.11001		
-3525	Northwards Housing Ltd		S.11001		
-3524	Northumbria Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1476	Northumberland National Park Authority		S.1313	1996-06-01	
-1475	Northumberland County Council		S.1313		
-3523	Northlink Ferries Ltd		S.1311	2006-07-01	
-3522	Northern Rock Traffic Management Ltd.		S.11001		
-3521	Northern Rock Properties Ltd.		S.11001		
-3520	Northern Rock plc		S.11001		2012-01-01
-3519	Northern Rock Homes Ltd.		S.11001		
-3518	Northern Rock Estates Ltd.		S.11001		
-3517	Northern Rock Asset Management plc		S.1311	2010-01-01	
-1474	Northern Lighthouse Board		S.1311	1905-04-29	
-3516	Northern Ireland Water Service		S.1311		
-3515	Northern Ireland Water Limited		S.1311		
-3514	Northern Ireland Water Council		S.1311		
-3513	Northern Ireland Utility Regulator		S.1311		
-3512	Northern Ireland Transport Holding Company (NITHC)		S.11001		
-1473	Northern Ireland Tourist Board		S.1311		
-3511	Northern Ireland Strategic Investment Board Ltd		S.1311		
-1472	Northern Ireland Statistics and Research Agency		S.1311		
-1739	Northern Ireland Social Care Council (NISCC)		S.1311	2001-10-01	
-3510	Northern Ireland Screen Commission		S.1311		
-3509	Northern Ireland Schools (En Bloc)		S.1311		
-3508	Northern Ireland Rural Development Council		S.1311		
-3507	Northern Ireland Review Body (Driver, Operator and Vehicle Licensing)		S.1311		
-3506	Northern Ireland Regional Medical Physics Agency (NIRMPA)		S.1311		
-3505	Northern Ireland Railways Company Ltd - (s NITHC)		S.11001		
-3504	Northern Ireland Public Sector Enterprise		S.11001		2009-12-01
-1471	Northern Ireland Prison Service		S.1311		
-3503	Northern Ireland Postal Services Committee		S.1311		2008-04-01
-1470	Northern Ireland Policing Board		S.1311		
-1469	Northern Ireland Police Fund		S.1311		
-1468	Northern Ireland Ombudsman		S.1311		
-1467	Northern Ireland Office		S.1311		
-3502	Northern Ireland Museums Council		S.1311		
-3501	Northern Ireland Memorial Fund		S.1311		2013-04-01
-3500	Northern Ireland Medical and Dental Training Agency		S.1311		
-1775	Northern Ireland Local Government Officer’s Superannuation Committee		S.1311		
-3499	Northern Ireland Library Authority		S.1311		
-1466	Northern Ireland Legal Services Commission		S.1311	2003-11-01	
-1465	Northern Ireland Law Commission		S.1311	2007-04-01	
-1464	Northern Ireland Judicial Appointments Commission		S.1311	2005-06-01	
-3498	Northern Ireland Industrial Tribunals		S.1311		
-3497	Northern Ireland Industrial Court		S.1311		
-1463	Northern Ireland Human Rights Commission		S.1311		
-1735	Northern Ireland Housing Executive (NIHE)		S.11001		
-3496	Northern Ireland Higher Education Council		S.1311		
-3495	Northern Ireland Health Promotion Agency		S.1311		2009-04-01
-3494	Northern Ireland Health and Social Care Trust Charitable Funds		S.1311		
-3493	Northern Ireland Guardian Ad Litem Agency (NIGALA)		S.1311		
-3492	Northern Ireland Government Departments (En Bloc)		S.1311		
-3491	Northern Ireland Fishery Harbour Authority		S.1311		
-3490	Northern Ireland Fire and Rescue Board		S.1311	2006-07-01	
-3489	Northern Ireland Environment Agency		S.1311	2008-07-01	
-3488	Northern Ireland Education and Library Boards		S.1311		
-3487	Northern Ireland Economic Development Council		S.1311		
-3486	Northern Ireland Economic Council		S.1311		
-3485	Northern Ireland Driver Vehicle Testing Agency		S.11001		
-3484	Northern Ireland District Councils (En Bloc)		S.1313		
-3483	Northern Ireland Disability Council		S.1311		
-3482	Northern Ireland Crown Court Rules Committee		S.1311	1905-05-31	
-1793	Northern Ireland Courts Service		S.1311		2010-04-01
-3481	Northern Ireland Courts and Tribunals Service		S.1311	2010-04-01	
-1826	Northern Ireland Council for the Curriculum Examinations & Assessment (NICCEA)		S.1311		
-3480	Northern Ireland Council for Postgraduate Medical and Dental Education		S.1311		
-3479	Northern Ireland Cooperation Overseas (NI-CO) Ltd		S.11001	2009-12-01	
-3478	Northern Ireland Consumer Committee for Electricity		S.1311		
-3477	Northern Ireland Consolidated Fund		S.1311		
-3476	Northern Ireland Community Relations Council		S.1311	1905-06-12	
-3475	Northern Ireland Commissioner for the Rights of Trade Union Members		S.1311		
-3474	Northern Ireland Commissioner for Protection Against Unlawful Industrial Action		S.1311		
-1462	Northern Ireland Child Support Agency		S.1311		2008-04-01
-3473	Northern Ireland Central Services Agency (NICSA)		S.1311		2009-04-01
-3472	Northern Ireland Central Investment Fund for Charities		S.12601		
-3471	Northern Ireland Building Regulations Advisory Committee		S.1311		
-3470	Northern Ireland Blood Transfusion Service Agency		S.1311		
-1461	Northern Ireland Authority for Energy Regulation		S.1311		
-1460	Northern Ireland Audit Office		S.1311	1987-04-01	
-3469	Northern Ireland Assembly Commission		S.1311		
-3468	Northern Ireland Ambulance Service Health and Social Care Trust, The		S.1311	2010-04-01	
-3467	Northern Ireland Airports Ltd		S.11001		1905-06-16
-3466	Northern Ireland Advisory Committee on Travellers		S.1311		
-3465	Northern Ireland Advisory Committee on Telecommunications		S.1311		
-3464	Northern Housing Consortium (NHC)		S.1313		
-3463	Northern Health and Social Care Trust		S.1311	2010-04-01	
-1857	Northern Health and Personal Social Services Board		S.1311		
-1459	Northamptonshire County Council		S.1313		
-1458	Northampton Borough Council		S.1313		
-1824	North Yorkshire Moors National Park Authority		S.1313	1996-06-01	
-1457	North Yorkshire County Council		S.1313		
-3459	North Western Region Electricity Consumers’ Committee		S.1311		
-1788	North West Regional Development Agency		S.1311		2012-07-01
-1456	North West Leicestershire District Council		S.1313		
-3458	North West Cultural Consortium		S.1311		2010-09-01
-1455	North Warwickshire Borough Council		S.1313		
-1454	North Tyneside Council		S.1313		
-3454	North South Language Body (An Foras Teanga North-South Body o Leid) (The)		S.1311	1999-12-01	
-1453	North Somerset Council		S.1313		
-3453	North Ronaldsay Aerodrome		S.1313		
-3452	North of Scotland Water Authority		S.11001		
-3451	North of Scotland Region Electricity Consumers’ Committee		S.1311		
-1452	North Norfolk District Council		S.1313		
-3449	North London Waste Authority		S.1313	1986-01-01	
-1451	North Lincolnshire Council		S.1313		
-3447	North Lanarkshire Municipal Bank Ltd		S.12501		
-1839	North Lanarkshire Council		S.1313		
-1450	North Kesteven District Council		S.1313		
-3446	North Kent Architecture Centre Ltd		S.1313		
-3445	North Hull Housing Action Trust		S.1311		
-1449	North Hertfordshire District Council		S.1313		
-3441	North Eastern Region Electricity Consumers’ Committee		S.1311		
-1810	North Eastern Education and Library Board		S.1311		
-3440	North East Wales Careers Service Ltd		S.1311	2013-04-01	
-3439	North East of Scotland Transport Partnership (NESTRANS)		S.1313	2005-12-01	
-1448	North East Lincolnshire Council		S.1313		
-1447	North East Derbyshire District Council		S.1313		
-1446	North Dorset District Council		S.1313		
-3437	North Devon Homes Limited		S.11001		
-3436	North Devon Council		S.1313		
-3435	North Connel (Oban) Aerodrome		S.1313		
-3433	North Berwick Harbour		S.11001		2015-12-02
-3431	North Ayrshire Municipal Bank Ltd		S.12501		
-1854	North Ayrshire Council		S.1313		
-1445	Norfolk County Council		S.1313		
-3430	Norfolk & Suffolk Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-3429	Norden Farm Centre Trust		S.1313		
-3428	Non Fossil Purchasing Agency Ltd		S.11001	2000-10-01	
-3425	NHS Trusts (England) (En Bloc)		S.1311		
-1444	NHS Trust Development Authority		S.1311	2012-06-01	
-3424	NHS Quality Improvement Scotland		S.1311		2011-04-01
-1443	NHS Purchasing and Supply Agency		S.1311		2010-03-01
-3423	NHS Professionals South West		S.1311		
-3422	NHS Professionals Limited		S.11001	2010-04-01	
-1442	NHS Professionals		S.1311		
-1441	NHS Pensions Agency		S.1311	2006-04-01	
-1440	NHS Logistics Authority		S.11001		
-1439	NHS Institute for Innovation and Improvement		S.1311		
-3421	NHS Health Scotland Board		S.1311	2003-04-01	
-1438	NHS Estates		S.11001		
-3420	NHS Education for Scotland		S.1311	2002-03-01	
-3419	NHS Direct NHS Trust (England)		S.1311	2007-04-01	
-3418	NHS Confederation, The		S.1311		
-3417	NHS Commissioning Board Special Health Authority		S.1311		2012-10-01
-3416	NHS Charities in England and Wales (En Bloc)		S.1311		
-1792	NHS Business Service Authority		S.1311		
-3415	NHS Board Endowment Funds (Scotland) - aka Scottish NHS Charities		S.1311	1905-05-25	
-1437	NHS Blood and Transplant		S.11001		
-3414	NHS 24		S.1311		
-3413	NFPA Scotland Ltd		S.11001	2005-07-01	
-3412	Nexus (Tyne and Wear Passenger Transport Executive)		S.1313		
-3410	Nexia Solutions Ltd. (s. BNFL)		S.11001		
-3408	Newry, Mourne and Down District Council		S.1313		
-3407	Newquay Port		S.1313		
-3406	Newport Transport Ltd		S.11001		
-1436	Newport City Council		S.1313		
-3404	Newport (IOW) Port		S.1313		
-3403	Newlyn Pier and Harbour Commissioners		S.11001		
-3399	Newham Homes Ltd		S.11001		2011-04-01
-3398	Newcastle-upon-Tyne MDC		S.1313		
-3397	Newcastle-upon-Tyne City Council		S.1313		
-1435	Newcastle-Under-Lyme Borough Council		S.1313		
-3396	Newcastle International Airport Ltd		S.11001		
-3393	Newark and Sherwood Homes Ltd		S.11001		
-1434	Newark and Sherwood District Council		S.1313		
-3390	New Video Channel America LLC [USA] (s BBCW)		S.11001		
-1433	New Opportunities Fund		S.1311		
-3383	New Millennium Experience Company Ltd		S.11001		
-1432	New Forest National Park Authority		S.1313	2005-04-01	
-1431	New Forest District Council		S.1313		
-3376	New Deal Task  Force		S.1311		2001-10-01
-3370	Network Rail Limited		S.1311	2004-04-01	
-3367	NESTA Trust, The		S.1311	2011-07-01	
-3366	NESTA Endowment Account (National Endowment for Science Technology and Arts)		S.1311		
-1430	Neath Port Talbot County Borough Council		S.1313		
-3364	NDA Archives Limited		S.1311	2014-07-01	
-3363	Navy, Army and Air Force Institute		S.11001		
-3362	Naval Recruiting and Training Agency		S.1311		2006-04-01
-3361	Naval Manning Agency		S.1311		2004-04-01
-3360	Naval Bases and Supply Agency		S.1311		
-3359	Naval Aircraft Repair Organisation		S.1311		
-1429	Natural Resources Wales		S.1311	2013-04-01	
-1428	Natural History Museum		S.1311		
-1723	Natural Environment Research Council, The		S.1311		
-1427	Natural England		S.1311		
-3358	National Youth Agency		S.1311		
-3357	National Westminster Bank plc		S.12201		
-1817	National Weights and Measurements Laboratory		S.1311		
-3356	National Waiting Times Centre Board		S.1311	2002-06-01	
-1773	National Treatment Agency		S.1311		2013-04-01
-3355	National Stone Centre		S.1313		
-3354	National Specialist Commissioning Advisory Group		S.1311		
-1426	National School of Government		S.1311		2012-03-01
-3353	National Savings Stock Register Cash Account		S.1311		
-3352	National Savings Bank (Ordinary and Investment accounts)		S.1311		
-3351	National Research Development Corporation		S.1311		
-1425	National Records of Scotland		S.1311	2011-04-01	
-1424	National Radiological Protection Board		S.1311		2005-04-01
-1772	National Probation Service for England and Wales		S.1311		
-1423	National Portrait Gallery		S.1311		
-1422	National Policing Improvement Agency		S.1311		2013-10-01
-1421	National Patient Safety Agency		S.1311		2012-10-01
-3350	National Parks Authorities (En Bloc)		S.1313		
-3349	National Nuclear Laboratories Ltd		S.11001	2009-04-01	
-3348	National Non Food Crop Centre		S.1311		2012-10-01
-1420	National Museums of Scotland		S.1311		
-1419	National Museums Liverpool		S.1311		
-3347	National Museums and Galleries on Merseyside		S.1311		
-3346	National Museums and Galleries of Wales		S.1311		
-1418	National Museums and Galleries of Northern Ireland		S.1311		
-3345	National Museum of Wales Pension Scheme		S.12901	2006-06-21	
-1417	National Museum of the Royal Navy		S.1311		
-1738	National Measurement Office, The		S.1311		
-3344	National Maritime Museum		S.1311		
-3343	National Lottery UK Sports Council Lottery		S.1311		
-3342	National Lottery Distribution Fund		S.1311		
-3341	National Lottery Commission		S.1311		
-3340	National Loans Fund		S.1311		
-3339	National Library of Wales Staff Superannuation Scheme		S.12901	2007-03-13	
-3338	National Library of Wales		S.1311		
-3337	National Library of Scotland		S.1311		
-3336	National Investment and Loans Office		S.1311		
-3335	National Insurance Local Tribunals		S.1311		
-3334	National Insurance Fund		S.1311		
-3333	National Insurance Contributions Office		S.1311		
-1796	National Institute of Health and Care Excellence		S.1311	2013-04-01	
-3332	National Institute for Health and Clinical Excellence (The)		S.1311		2005-04-01
-3331	National Institute for Clinical Excellence (The)		S.1311		2005-04-01
-3330	National Heritage Memorial Fund Investment Account		S.1311		
-1416	National Heritage Memorial Fund		S.1311		
-3329	National Health Service Trusts (Wales)		S.1311	1905-06-28	
-3328	National Health Service Trusts (England)		S.1311		
-3327	National Health Service Tribunal		S.1311		
-3326	National Health Service Training Authority		S.1311		
-3325	National Health Service Supplies Authority		S.1311		
-3324	National Health Service Professionals South West		S.1311		
-3323	National Health Service Pensions Agency		S.1311		
-3322	National Health Service Litigation Authority		S.1311		
-3321	National Health Service Information Authority		S.1311		2005-04-01
-3320	National Health Service Foundation Trusts (England)		S.1311		
-3319	National Health Service Estates		S.11001		
-3318	National Health Service Commissioning Board, The		S.1311	2012-10-01	
-3317	National Health Service Central Register		S.1311		
-3316	National Health Service Business Services Authority		S.1311		
-1415	National Gallery		S.1311		
-3315	National Galleries of Scotland		S.1311		
-3314	National Fuel Distributors Ltd - (s HI)		S.11001		
-1414	National Fraud Authority		S.1311	2008-10-01	
-1413	National Forest Company		S.1311		
-3313	National Expert Group on Transboundary Air Pollution		S.1311		
-3312	National Exhibition Centre Limited		S.1313		2015-05-01
-1806	National Endowment for Science and Technology and the Arts (NESTA)		S.1311		2012-04-01
-3311	National Employment Savings Trust Corporation (NEST)		S.12901		
-3310	National Employment Panel		S.1311		
-1412	National Employer Advisory Board		S.1311		
-3309	National Disability Council		S.1311		
-3308	National Curriculum Council		S.1311		
-1411	National Criminal Intelligence Service		S.1311		2006-04-01
-1410	National Crime Squad		S.1311		2006-04-01
-1409	National Crime Agency		S.1311	2013-10-01	
-3306	National Council for Education and Training for Wales		S.1311		
-3305	National Consumers Consultative Committee (Electricity) (NCCC)		S.1311		
-3304	National Consumer Council		S.1311		2008-04-01
-1408	National College for Teaching and Leadership		S.1311	2013-04-01	
-1407	National College for School Leadership		S.1311		2013-04-01
-3303	National Clinical Assessment Authority (NCAA)		S.1311		2005-04-01
-1406	National Care Standards Commission		S.1311		
-3302	National Board for Nursing, Midwifery and Health Visiting for Scotland		S.1311		2002-04-01
-3301	National Board for Nursing, Midwifery and Health Visiting for Northern Ireland		S.1311		2002-04-01
-1405	National Blood Authority		S.11001		
-1726	National Biological Standards Board (UK)		S.1311		2009-04-01
-3300	National Audit Office		S.1311		
-3299	National Association of Citizens Advice Bureau (England and Wales) (The)		S.1311		2013-11-01
-3298	National Assembly for Wales		S.1311		
-1404	National Army Museum		S.1311		
-3297	National Archives of Scotland		S.1311		2011-04-01
-1887	National Archives		S.1311		
-3296	National Air Traffic Services Ltd - (s CAA)		S.11001		
-3295	National Advisory Council for the Employment of People with Disabilities		S.1311		
-3294	Nairn Port		S.1313		
-3291	N.I.R Travel Limited - (s NITHC)		S.11001		
-3290	N.I.R Leasing Limited - (s NITHC)		S.11001		
-3288	Musselburgh Port		S.1313		
-1785	Museums Libraries and Archives Council		S.1311		2012-05-01
-3287	Museums and Galleries Commission		S.1311		
-3286	Museum of Science and Industry in Manchester		S.1311		2012-01-01
-3285	Museum of London		S.1313		
-3284	Museum of Kent Life Trust		S.1313		
-3280	Multimedia Ventures Ltd (50%) (sWS) (Associate)		S.11001		2013-06-13
-3270	Mortgage Express		S.12201		
-3269	Moredun Research Institute		S.1311		
-3268	Moray Council		S.1313		
-3266	Montrose Port		S.11001		2015-12-02
-1403	Monopolies and Mergers Commission		S.1311		
-1402	Monmouthshire County Council		S.1313		
-3263	Monitor – Independent Regulator of NHS Foundation Trusts		S.1311		
-3262	Money Advice Service		S.1311	2011-04-01	
-1401	Mole Valley District Council		S.1313		
-3255	MNE Ltd.		S.11001		
-3253	Misuse of Drugs Tribunal		S.1311		
-3252	Misuse of Drugs Professional Panel		S.1311		
-3251	Misuse of Drugs Advisory Board		S.1311		
-1400	Ministry of Justice		S.1311		
-1808	Ministry of Defence Police & Guarding Agency		S.1311		2012-04-01
-1399	Ministry of Defence		S.1311		
-3247	Mineworker's Pension Scheme		S.12901	1994-10-31	
-3246	Minehead Port		S.1313		
-1398	Milton Keynes Council		S.1313		
-3245	Milton Keynes - (s NTC)		S.1311		
-1397	Millennium Commission		S.1311		
-1753	Milk Development Council (MDC)		S.1311		
-3239	Military Survey		S.1311		
-3238	Milford Haven Port Authority		S.11001		
-1884	Midlothian Council		S.1313		
-3235	Midlands Region Electricity Consumers Committee		S.1311		
-3233	Middlesbrough Council		S.1313		
-3232	Middle Level Commissioners		S.1313		
-3231	Mid Ulster District Council		S.1313		
-1396	Mid Sussex District Council		S.1313		
-1395	Mid Suffolk District Council		S.1313		
-1394	Mid Devon District Council		S.1313		
-3230	Mid and East Antrim Borough Council		S.1313		
-3229	Microbiological Research Authority		S.1311		
-3228	Metropolitan Police Committee		S.1311		2000-01-01
-3227	Metropolitan Police Authority		S.1313		2012-01-01
-3224	Metronet Rail SSL Holdings Ltd		S.11001		1905-07-03
-3223	Metronet Rail BCV Holdings Ltd		S.11001		1905-07-03
-3221	Meteorological Office		S.11001		
-1393	Merthyr Tydfil County Borough Council		S.1313		
-3217	Merseytravel - (Merseyside Passenger Transport Executive)		S.11001		
-3216	Merseyside Waste Authority		S.1313	1986-01-01	
-3215	Merseyside Passenger Transport Executive - (s PTE)		S.1313	1998-04-01	
-3214	Merseyside Development Corporation		S.11001		
-3213	Merseyside Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-3212	Merseyside and North Wales Region Electricity Consumers’ Committee		S.1311		
-3205	Merchant Navy Reserve		S.1311		
-3204	Mental Welfare Commission for Scotland		S.1311		
-3203	Mental Health Review Tribunal for Wales		S.1311		
-3202	Mental Health Review Tribunal for Northern Ireland		S.1311		
-3201	Mental Health Review Tribunal		S.1311		
-3200	Mental Health Commission for Northern Ireland		S.1311		2009-04-01
-1392	Mental Health Act Commission		S.1311		2009-03-01
-1391	Mendip District Council		S.1313		
-1390	Melton Borough Council		S.1313		
-1389	Medway Council		S.1313		
-3197	Medicines Commission		S.1311		
-1388	Medicines and Healthcare products Regulatory Agency		S.11001		
-3196	Medical Workforce Standing Advisory Committee		S.1311		1905-06-25
-1387	Medical Supplies Agency		S.1311		2005-03-01
-3195	Medical Research Council Technology		S.11001	2010-04-01	
-1386	Medical Research Council		S.1311		
-3194	Medical Practices Committee		S.1311		
-3193	Medical Devices Agency		S.1311		
-3192	Medical Appeals Tribunal		S.1311		
-3191	Medical Appeal Tribunals Northern Ireland		S.1311		
-1385	Meat Hygiene Service		S.1311		2010-04-01
-3190	Meat Hygiene Appeals Tribunal for England and Wales		S.1311		
-3189	Meat Hygiene Advisory Committee		S.1311		2004-09-01
-1742	Meat and Livestock Commission (MLC)		S.1311		
-3188	Measurement Advisory Committee		S.1311		
-3187	Maze / Long Kesh Development Corporation		S.1311	2012-09-01	
-3186	Mayor's Office for Policing and Crime		S.1313	2012-01-01	
-3183	Master of the Rolls		S.1311		
-1384	Marshall Aid Commemoration Commission		S.1311		
-1383	Maritime and Coastguard Agency		S.1311		
-3173	Marine Scotland		S.1311	2009-04-01	
-3172	Marine Safety Agency		S.1311		
-1382	Marine Management Organisation		S.1311		
-1850	Marine and Fisheries Agency		S.1311		
-3171	Marine and Aviation (War Risks) Fund		S.1311		
-3167	Mansfields Group Ltd - (s Remploy Ltd)		S.11001		
-3166	Mansfields (Norwich) Ltd - (s Remploy Ltd )		S.11001		
-1381	Mansfield District Council		S.1313		
-3159	Manchester Investment and Development Agency Service Ltd		S.1313		
-1380	Manchester City Council		S.1313		
-3157	Manchester Airport plc		S.11001/3	2013-02-01	
-3156	Manchester Airport Holdings Limited		S.12701/03	2013-02-01	
-3155	Manchester Airport Group Property Services Ltd		S.11001/3	2013-02-01	
-3154	Manchester Airport Group Property Developments Ltd		S.11001/3	2013-02-01	
-3153	Manchester Airport Group plc		S.11001/3	2013-02-01	
-3152	Manchester Airport Group Finance Ltd		S.11001/3	2013-02-01	
-3151	Manchester Airport Finance Ltd (s MA)		S.11001		2006-07-01
-3150	Manchester Airport Finance Holdings Ltd		S.11001/3	2013-02-01	
-3149	Manchester Airport Employment Services Ltd (s MA)		S.11001		2006-07-01
-3148	Manchester Airport Building Ltd (s MA)		S.11001		2006-07-01
-3147	Manchester (Barton) Aerodrome		S.1313		
-1379	Malvern Hills District Council		S.1313		
-3146	Mallaig Harbour		S.11001		2015-12-02
-1378	Maldon District Council		S.1313		
-1377	Maidstone Borough Council		S.1313		
-3142	Magnox South Ltd. (s. BNFL)		S.1311		2011-01-01
-3141	Magnox North Ltd. (s. BNFL)		S.1311		2011-01-01
-3140	Magnox Limited		S.1311	2011-01-01	
-3139	Magnox Electric plc		S.11001		2005-04-01
-3138	Magnox Electric Ltd (s BNFL)		S.1311		2008-10-01
-3133	Magistrates Courts Rules Committee (Northern Ireland)		S.1311	1905-06-03	
-3132	Magistrates Courts Rule Committee		S.1311		2012-09-01
-3131	Magistrates Courts (En Bloc)		S.1311	2005-04-01	
-3130	MacFarlane Trust		S.1311		
-3129	Macduff Port		S.1313		
-3128	Macaulay Research and Consultancy Services Ltd		S.11001		
-3127	Macaulay Land Use Research Institute		S.1311		2011-04-01
-3123	Lyme Regis Port		S.1313		
-3120	Luton International Airport Ltd		S.11001		1998-08-01
-1376	Luton Borough Council		S.1313		
-3115	LUL Nominee SSL Ltd		S.1313	2008-05-01	
-3114	LUL Nominee BCV Ltd		S.1313	2008-05-01	
-1375	Low Pay Commission		S.1311		
-3112	Low Level Waste Repository (LLWR) Ltd		S.1311	2008-04-01	
-3111	Low Carbon Contracts Company		S.1311	2014-08-01	
-1374	Loughs Agency		S.1311	1999-12-01	
-3108	Lothian Buses plc		S.11001		
-3104	Lord Chief Justice, The		S.1311		
-3103	Lord Chancellor's Legal Aid Advisory Committee (Northern Ireland)		S.1311		2006-03-01
-1373	Lord Chancellor's Department		S.1311		2005-06-01
-3097	Londonderry Port and Harbour Commissioners		S.11001		
-3096	London Waste and Recycling Board		S.1313		
-3095	London Underground Ltd		S.11001		
-3094	London Transport Users Committee (LTUC)		S.1313		
-3093	London Transport Museum (Trading) Ltd		S.11001	2008-04-01	
-3092	London Transport Museum (s.TfL)		S.1313	1905-06-22	
-1372	London Thames Gateway Development Corporation		S.1311		2013-02-01
-3090	London River Services Ltd (s.TfL)		S.11001		
-3089	London Regional Transport		S.11001		
-3088	London Region Electricity Consumers’ Committee		S.1311		
-3087	London Pensions Fund Authority (operations)		S.11001		
-3086	London Organising Committee of the Olympic Games (LOCOG)		S.11001		2013-06-01
-3085	London Olympic Bid Company / London 2012 Ltd		S.1311		2010-04-01
-3084	London Luton Airport Ltd		S.1313	1998-08-01	
-3083	London Legacy Development Corporation		S.1313	2012-03-01	
-3081	London Fire and Emergency Planning Authority, The		S.1313		
-3080	London Docklands Development Corporation - (LDDC)		S.11001		
-3078	London Development Agency		S.1313		2012-03-01
-3076	London Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-3075	London Buses Ltd (s.TfL)		S.1313	1905-06-22	
-3074	London Bus Services Ltd (s.TfL)		S.11001		
-3073	London Boroughs (En Bloc)		S.1313		
-1371	London Borough of Wandsworth		S.1313		
-1370	London Borough of Waltham Forest		S.1313		
-1369	London Borough of Tower Hamlets		S.1313		
-1368	London Borough of Sutton		S.1313		
-1367	London Borough of Southwark		S.1313		
-1366	London Borough of Richmond upon Thames		S.1313		
-1365	London Borough of Redbridge		S.1313		
-1364	London Borough of Newham		S.1313		
-1363	London Borough of Merton		S.1313		
-1362	London Borough of Lewisham		S.1313		
-1361	London Borough of Lambeth		S.1313		
-1360	London Borough of Islington		S.1313		
-1359	London Borough of Hounslow		S.1313		
-1358	London Borough of Hillingdon		S.1313		
-1357	London Borough of Havering		S.1313		
-1356	London Borough of Harrow		S.1313		
-1355	London Borough of Haringey		S.1313		
-1815	London Borough of Hammersmith and Fulham		S.1313		
-1354	London Borough of Hackney		S.1313		
-1353	London Borough of Enfield		S.1313		
-1352	London Borough of Ealing		S.1313		
-1351	London Borough of Croydon		S.1313		
-1350	London Borough of Camden		S.1313		
-1349	London Borough of Bromley		S.1313		
-1348	London Borough of Brent		S.1313		
-1347	London Borough of Bexley		S.1313		
-1346	London Borough of Barnet		S.1313		
-1345	London Borough of Barking and Dagenham		S.1313		
-3072	London Authorities Mutual Limited (The)		S.12801		
-3071	London and Partners Ltd		S.1313	2011-04-01	
-3070	London and Partners International Ltd		S.1313	2011-04-01	
-3068	London & Continental Stations & Property Limited		S.11001		2008-12-01
-3067	London & Continental Railways (LCR) Limited		S.11001	2013-09-01	
-3066	Logistic Information Systems Agency		S.1311		2001-04-01
-3061	Lochmaddy Port		S.1313		
-3058	Loch Lomond and the Trossachs National Park Authority		S.1313	2002-07-01	
-3056	Local Partnerships LLP		S.11001	2009-07-01	
-3055	Local Learning and Skills Councils		S.1313		
-3054	Local Government Staff Commission (England)		S.1311		
-3053	Local Government Staff Commission		S.1311		
-3052	Local Government Residuary Body, (England)		S.1311		
-3051	Local Government Residuary Body		S.1311		
-3050	Local Government Property Commission (Scotland)		S.1311		
-3049	Local Government Pension Scheme		S.12901		
-3048	Local Government International Bureau		S.1313		
-3047	Local Government Information Unit		S.1313		
-3046	Local Government Data Unit Wales		S.1313		
-3045	Local Government Commission for England		S.1311		
-3044	Local Government Boundary Commission for Wales		S.1311		
-3043	Local Government Boundary Commission for Scotland		S.1311		
-3042	Local Government Boundary Commission for England		S.1311		
-3041	Local Government Association (Properties) Ltd		S.1313		
-3040	Local Government Association		S.1313		
-3039	Local Enterprise Development Unit		S.1311		
-1746	Local Better Regulation Office (LBRO)		S.1311		2012-04-01
-3038	Local Authority Bus and Tram Companies		S.11001		
-3037	Local Authority Airports		S.11001		
-3036	Local Authorities Departments (En Bloc)		S.1313		
-3035	Lloyds Banking Group plc subsidiaries		S.11001		
-3034	Lloyds Banking Group plc		S.12301		2014-03-01
-3033	Lloyds Bank Private Banking Limited		S.12201		2014-03-01
-3032	Lloyds Bank plc		S.12201		2014-03-01
-3031	Lloyds Bank (BLSA)		S.12201		2014-03-01
-3029	Livingstone Development Corporation		S.11001		
-3028	Living East (East of England Cultural Consortium)		S.1311		2010-09-01
-1344	Livestock and Meat Commission for Northern Ireland		S.1311		
-3022	Liverpool City Region Combined Authority		S.1313	2014-04-01	
-1343	Liverpool City Council		S.1313		
-3021	Littlehampton Harbour Board		S.11001		
-3018	Lisburn and Castlereagh City Council		S.1313		
-3015	LINK/TCS Board		S.1311		
-1342	Lincolnshire County Council		S.1313		
-3007	Limehouse Developments Ltd (dormant) - (s BWB)		S.11001		
-3005	Life and other Annuities Warrant Account		S.1311		
-1341	Lichfield District Council		S.1313		
-3002	Library and Information Services Council (Wales)		S.1311		
-3001	Library and Information Commission		S.1311		
-2999	Lewisham Homes Ltd		S.11001		
-1340	Lewes District Council		S.1313		
-2996	Lerwick Harbour		S.11001		2015-12-02
-2993	Leigh Port		S.1313		
-1339	Leicestershire County Council		S.1313		
-1338	Leicester City Council		S.1313		
-2990	Legal Services Ombudsman		S.1311		
-2989	Legal Services Consultative Panel		S.1311		
-2988	Legal Services Complaints Commissioner		S.1311		
-1337	Legal Services Commission		S.1311		2013-04-01
-1336	Legal Services Board		S.1311		
-2987	Legal Secretariat to the Law Officers, the		S.1311		
-1335	Legal Aid Board		S.1311		
-1334	Legal Aid Agency		S.1311	2013-04-01	
-2986	Legacy Trust UK Ltd		S.1311		
-2985	Leeds West Homes Ltd		S.11001		
-2984	Leeds South Homes Ltd		S.11001		
-2983	Leeds South East Homes Ltd		S.11001		
-2982	Leeds Port - (s BWB)		S.11001		
-2981	Leeds North West Homes Ltd		S.11001		
-2978	Leeds East Homes Ltd		S.11001		
-1333	Leeds City Council		S.1313		
-2977	Leeds Bradford International Airport		S.11001		
-2975	Leed North East Homes Ltd		S.11001		
-2974	Lee Valley Regional Park Authority		S.1313	1967-01-01	
-1744	Leasehold Advisory Service, The		S.1311		
-2970	LEASE Conferences Ltd		S.11001		
-2969	Learning Trust (The)		S.11001		
-2968	Learning and Teaching Scotland		S.1311		2011-04-01
-2967	Learning and Skills Improvement Service (LSIS)		S.1311		2013-07-01
-2966	Learning and Skills Development Agency		S.11001		
-1332	Learning and Skills Council		S.1311		
-2965	LCR Treasury Management Limited		S.11001		2011-09-01
-2964	LCR Finance plc		S.1311	2009-06-01	
-2962	Law Reform Advisory Committee for Northern Ireland		S.1311		2007-03-31
-1331	Law Commission		S.1311		
-2958	Larch Plastics Ltd - (s Remploy Ltd)		S.11001		
-2957	Larch Packaging Ltd - (s Remploy Ltd)		S.11001		
-2956	Larch Industries Ltd - (s Remploy Ltd)		S.11001		
-2954	Larch Cartons Ltd - (s Remploy Ltd)		S.11001		
-2953	Langstone Harbour Board		S.11001		
-2949	Lands Tribunal for Scotland		S.1311		
-2948	Lands Tribunal		S.1311		
-2947	Land Registry, Her Majesty’s		S.11001		
-1791	Land Registration Rules Committee		S.1311		
-1330	Land Registers of Northern Ireland		S.1311		
-2946	Land Reform Advisory Committee for Northern Ireland		S.1311		
-2945	Land Authority for Wales		S.11001		
-2944	Land and Property Services		S.1311		
-1329	Lancaster City Council		S.1313		
-1328	Lancashire County Council		S.1313		
-2940	Lambeth Living Ltd		S.11001		
-1327	Lake District National Park Authority		S.1313	1996-06-01	
-2938	Laganside Corporation		S.1311		
-2933	Lace Hall Ltd, The		S.1313		
-1326	Labour Relations Agency		S.1311		
-2932	Laboratory Services Advisory Committee		S.1311		
-2931	KXC Landowners Limited		S.11001		
-1325	Knowsley Metropolitan Borough Council		S.1313		
-2926	Know How Fund Advisory Board		S.1311		1905-06-21
-2923	Kirkwell Port		S.1313		
-2922	Kirklees Theatre Trust		S.1313		
-2921	Kirklees Stadium Development Ltd		S.1313		
-2920	Kirklees Neighbourhood Housing Ltd		S.11001		
-2919	Kirklees Metropolitan Borough Council		S.1313		
-2918	Kirklees Media Centre		S.1313		
-2916	Kirklees Henry Boot Partnership Ltd		S.1313		
-2915	Kirklees Community Association		S.1313		
-2911	Kingston upon Hull City Council		S.1313		
-2907	Kings College Hospital NHS Trust		S.1311		2006-12-01
-2908	King's Lynn and West Norfolk Borough Council		S.1313		
-2898	Kielder Property Management Ltd		S.11001		
-1324	Kettering Borough Council		S.1313		
-2892	Kent, Surrey & Sussex Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1323	Kent County Council		S.1313		
-2891	Kensington and Chelsea Tenant Management Organisation Ltd		S.11001		
-2883	jv. UKTV2 - UK Gold Holdings Ltd (50%) (sBBCW)		S.11001		
-2882	jv. UKTV1 - UK Channel Management Ltd (50%) (sBBCW)		S.11001		
-2881	jv. JV Programmes LLC [USA] (50%) (sBBCW)		S.11001		
-2880	JV Network LLC [USA] (50%) (sBBCW) (Associate)		S.11001		
-2879	Juvenile Justice Board		S.1311		
-2878	Justices of the Peace Advisory Committees (Scotland)		S.1311		
-2876	Judicial Studies Board		S.1311		2011-04-01
-1322	Judicial Office		S.1311	1905-06-28	
-2875	Judicial College		S.1311	2011-04-01	
-2874	Judge Advocate General		S.1311		
-2869	Joint Prison/Probation Accreditation Panel		S.1311		
-1321	Joint Nature Conservation Committee		S.1311		
-2868	Joint Fire and Rescue Boards (Scotland)		S.1313		2013-04-01
-2867	Joint Committee on Vaccination and Immunisation		S.1311		2012-07-01
-2866	Joint Air Reconnaissance Intelligence Centre		S.1311		
-2858	Jobcentre Plus		S.1311	2002-04-01	
-2849	ITSO Services Ltd		S.11001		2013-01-01
-2848	ITSO Ltd		S.11001		2013-01-01
-2847	IT Services Ltd - (s BNFL)		S.11001		
-2846	Issue Department		S.121		
-2844	Islwyn Borough Transport Ltd		S.11001		2010-01-01
-2840	Islecare		S.1313		
-1320	Isle of Wight Council		S.1313		
-2839	Isle of Skye Aerodrome		S.1313		
-1319	Isle of Anglesey County Council		S.1313		
-2834	Irvine Development Corporation		S.11001		
-2832	Irish Land Purchase Fund		S.1311		
-2831	Ipswich Buses Ltd		S.11001		
-1318	Ipswich Borough Council		S.1313		
-1765	Investors in People UK (IipUK)		S.1311		
-1317	Investigatory Powers Tribunal		S.1311		
-2830	Invest Northern Ireland		S.1311		
-2829	Inverness Harbour		S.11001		2015-12-02
-1883	Inverclyde Council		S.1313		
-2828	Inverary Port		S.1313		
-2827	Inventures		S.11001		
-2826	Intervention Board for Agricultural Produce		S.1311		
-2825	Intervention Board		S.1311		
-2824	InterTradeIreland		S.1311	1999-12-01	
-2823	International Rail Regulator (IRR)		S.1311		
-2822	International Oil and Gas Business Advisory Board		S.1311		2002-04-01
-2821	International Nuclear Services Ltd - (s BNG / BNFL)		S.11001		
-2820	Internal Drainage Boards		S.1313		
-2819	Interception of Communications Tribunal		S.1311		
-2818	Intelligence Services Tribunal		S.1311		
-2817	Integrated Transport Authorities		S.1313	2009-02-01	
-2815	Intack Services Limited		S.11001		
-2814	Institutions of Further Education (Northern Ireland)		S.1311	1905-06-11	
-2813	Institution for Further Education (IFE)		S.11001		2014-11-11
-2812	Institute of Terrestrial Ecology		S.1311		
-2811	Institute of Oceanographic Sciences		S.1311		
-2810	Institute of Hydrology		S.1311		
-2809	Institute of Animal Physiology		S.1311		
-2808	Institute for Animal Health		S.1311		2012-10-01
-2807	Insolvency Service Investment Account		S.1311		
-1882	Insolvency Service		S.1311		
-1316	Insolvency Rules Committee		S.1311		
-1315	Insolvency Practitioners Tribunal		S.1311		
-2806	Inshore Fisheries and Conservation Authorities (England)		S.1313	2011-04-01	
-2803	Inland Waterways Amenity Advisory Council		S.1311		
-2802	Inland Waterways Advisory Council		S.1311		2012-07-01
-2801	Inland Revenue		S.1311		
-2800	Inland Drainage Boards		S.1313		
-2799	Information Tribunal		S.1311		
-1764	Information Commissioner		S.1311		
-2798	Industry Department for Scotland		S.1311		
-2797	Industrial Tribunals (Northern Ireland)		S.1311		
-2796	Industrial Tribunal Service		S.1311		
-2795	Industrial Training Boards		S.1311		
-2794	Industrial Research and Technology Unit (Advisory Board)		S.1311		
-1314	Industrial Injuries Advisory Council		S.1311		
-2792	Industrial Development Board for Northern Ireland		S.1311		
-1313	Industrial Development Advisory Board		S.1311		
-2791	Indian Family Pension Funds Body of Commissioners		S.1311		2001-05-01
-1312	Independent Television Commission		S.1311		
-2790	Independent Scientific Group on Cattle TB (ISG)		S.1311		
-1311	Independent Safeguarding Authority		S.1311		2012-12-01
-2789	Independent Review Services for Social Fund		S.1311		
-2788	Independent Review Panel on the Classification of Borderline Medicines		S.1311		
-1310	Independent Police Complaints Commission		S.1311		
-2787	Independent Parliamentary Standards Authority		S.1311		
-2786	Independent Monitoring Board for the Military Corrective Training Centre (MCTC) Colchester		S.1311		
-1309	Independent Living Fund		S.1311		
-2785	Independent Housing Ombudsman Limited		S.1311		
-1718	Independent Commission for Aid Impact, The		S.1311	2011-05-01	
-2784	Independent Advisory Group on Teenage Pregnancy		S.1311		2010-12-01
-2780	Improvement and Development Agency		S.1313		
-2779	Import Parity Price Panel		S.1311		
-1308	Imperial War Museum		S.1311		
-2777	Immigration Services Tribunal		S.1311		
-2776	Immigration Appellate Authorities		S.1311		2005-04-01
-2775	Immigration Appeal Tribunal		S.1311		
-2773	Ilfracombe Port		S.1313		
-2772	Ilex Urban Regeneration Company Ltd		S.1311	2003-07-01	
-1307	Identity and Passport Service		S.1311		2013-05-01
-2770	IBS Viridian Ltd - (s BNFL)		S.11001		
-2769	Hywel Dda Health Board		S.1311	2009-06-01	
-1306	Hyndburn Borough Council		S.1313		
-1847	Hydrographic Office		S.11001		
-1305	Hybu Cig Cymru - Meat Promotion Wales		S.1311	2007-04-01	
-2764	HW Poole and Son  Ltd - (s Remploy Ltd)		S.11001		
-1304	Huntingdonshire District Council		S.1313		
-2756	Humberside, Lincolnshire & North Yorkshire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-2755	Humberside International Airport Ltd (s MA)		S.11001		2012-08-01
-2754	Humber Bridge Board		S.11001	1998-04-01	
-1303	Human Tissue Authority		S.1311		
-2753	Human Genetics Commission		S.1311		
-1302	Human Fertilisation and Embryology Authority		S.1311		
-2750	Hull Resettlement Project		S.1313		
-2749	Hull Marina Ltd		S.1313		
-2745	HS1 Ltd		S.11001		2010-11-01
-2744	Hoy (Longhope) Aerodrome		S.1313		
-2741	Housing Revenue Account		S.11001	1990-04-01	
-2735	Housing for Wales		S.1311		
-2734	Housing Corporation (The)		S.1311		
-2733	Housing Benefit Review Boards		S.1311		
-2732	Housing Action Trusts		S.1311		
-2730	Houses of Parliament		S.1311		
-1301	House of Lords Appointments Commission		S.1311		
-2728	Hounslow Homes Ltd		S.11001		
-2720	Horticulture Research International		S.1311		
-1813	Horticulture Development Council		S.1311		
-2719	Horticultural Development Company Ltd		S.1311		
-1300	Horsham District Council		S.1313		
-2718	Horserace Totaliser Board (HTB) (The Tote)		S.11001		
-1299	Horserace Betting Levy Board		S.1311		
-2717	Horserace Betting Levy Appeals Tribunal for Scotland		S.1311		1905-06-24
-2716	Horserace Betting Levy Appeals Tribunal for England and Wales		S.1311		
-2713	Horniman Museum		S.1311		
-2708	Hopetoun Quay Ltd - (a BWB)		S.11001		
-2707	Hope Cove Harbour Commissioners		S.11001		
-2705	Honours Scrutiny Committee		S.1311		
-2704	Honorary Investment Advisory Committee		S.1311		1905-06-22
-2702	Homes in Sedgemoor Ltd		S.11001		
-2701	Homes in Havering Ltd		S.11001		2012-10-01
-2699	Homes for Northumberland Ltd		S.11001		
-2697	Homes for Islington Ltd		S.11001		2012-04-01
-2696	Homes for Haringey Ltd		S.11001		
-1298	Homes and Communities Agency		S.1311		
-1297	Home-Grown Cereals Authority		S.1311		
-2692	Home Service Group (HS) - (s BBC)		S.11001		
-1296	Home Office		S.1311		
-2688	Holywell Trust		S.1313		
-2681	Hobart Investments Ltd (HI) - (s BCC)		S.11001		
-2680	HM Treasury UK Sovereign Sukuk Plc		S.1311	2014-05-01	
-1846	HM Inspectorate of Education		S.1311		2011-04-01
-2678	Historical Manuscripts Commission (The Royal Commission on Historical Manuscripts)		S.1311		
-2677	Historic Scotland		S.1311		2015-04-01
-1758	Historic Royal Palaces Trust		S.11001		
-2676	Historic Royal Palaces Enterprises Ltd		S.11001		
-2675	Historic Monuments Council (Northern Ireland)		S.1311		
-2674	Historic Environment Scotland		S.1311	2015-10-01	
-2673	Historic Environment Advisory Council		S.1311		2010-07-01
-2672	Historic England Limited		S.1311	2014-11-24	
-2671	Historic Buildings Council for Wales		S.1311		2006-04-01
-2670	Historic Buildings Council for Scotland		S.1311		2003-06-01
-2669	Historic Buildings Council for Northern Ireland		S.1311	1905-05-27	
-2668	Historic Buildings Council for England		S.1311		1905-06-06
-1295	Hinckley and Bosworth Borough Council		S.1313		
-2665	Hillingdon Homes Ltd		S.11001		2010-10-01
-2660	Hill Farming Advisory Sub-Committee for Wales		S.1311		
-2659	Hill Farming Advisory Committee for Scotland		S.1311		1905-06-24
-2658	Hill Farming Advisory Committee for England, Wales and Northern Ireland (HFAC)		S.1311		
-1294	Highways Agency		S.1311		
-2655	Highlands and Islands Transport Partnership (HITRANS)		S.1313	2005-12-01	
-2654	Highlands and Islands Enterprise		S.1311		
-2653	Highlands and Islands Airports Ltd		S.1311		
-2652	Highlands and Islands Airports		S.11001		
-2651	Highlands & Islands Enterprise		S.11001		
-2650	Highland Regional Council Harbour		S.1313		
-2649	Highland Council		S.1313		
-2648	Higher Education Funding Council for Wales		S.1311		
-1293	Higher Education Funding Council for England		S.1311		
-1292	High Speed Two (HS2) Limited		S.1311	2009-01-01	
-2647	High Peak Community Housing Ltd		S.11001		2013-05-01
-1291	High Peak Borough Council		S.1313		
-2642	HGCA Ltd		S.1311		
-1290	Hertsmere Borough Council		S.1313		
-1289	Hertfordshire County Council		S.1313		
-2636	Hertfordshire Career Services Ltd		S.1313		
-1778	Heritage Lottery Fund		S.1311		
-1288	Herefordshire Council		S.1313		
-2633	Her Majesty's Treasury		S.1311		
-2632	Her Majesty's Revenue & Customs		S.1311		
-2631	Her Majesty's Prison Service		S.1311		
-2630	Her Majesty's Passport Service		S.1311	2013-05-01	
-2629	Her Majesty's Customs and Excise		S.1311		
-1888	Her Majesty's Crown Prosecution Service Inspectorate		S.1311		
-2628	Her Majesty's Courts and Tribunals Service		S.1311	2011-04-01	
-2627	Her Majesty's Court Service		S.1311		2011-04-01
-2618	Hemel Hempstead - (s NTC)		S.1311		
-2616	Helensburgh Port		S.1313		
-2613	Heeley City Farm Ltd		S.1313		
-1287	Hearing Aid Council		S.11001		2010-07-01
-2606	Healthwatch England		S.1311	2013-04-01	
-2605	Healthcare Improvement Scotland		S.1311	2010-04-01	
-1286	Healthcare Commission		S.1311		2009-03-01
-2604	Health Technology Board for Scotland		S.1311		2003-01-01
-1285	Health Research Authority		S.1311	2011-12-01	
-1284	Health Protection Agency		S.1311		2013-04-01
-2603	Health Promotion Authority for Wales		S.1311		
-2602	Health Estates (Northern Ireland)		S.1311		
-1283	Health Education England		S.1311	2012-06-01	
-2601	Health Education Board for Scotland		S.1311		2003-04-01
-4848	Health Education Authority		S.1311		
-4847	Health Development Agency		S.1311		2005-04-01
-4846	Health Commission Wales		S.1311		2010-04-01
-4845	Health Boards (Scotland) (En Bloc)		S.1311		
-4844	Health Authorities (Wales) (En Bloc)		S.1311		2003-04-01
-4843	Health Authorities (England) (En Bloc)		S.1311		2002-10-01
-4842	Health Appointments Advisory Committee		S.1311		2001-06-01
-4841	Health and Social Services Trusts		S.1311		2009-04-01
-4840	Health and Social Services Councils (Northern Ireland) (En Bloc)		S.1311		2009-04-01
-4839	Health and Social Services Boards (Northern Ireland) (En Bloc)		S.1311		2009-04-01
-4838	Health and Social Care Trusts (Northern Ireland) (En Bloc)		S.1311	2010-04-01	
-4837	Health and Social Care Regulation and Quality Improvement Authority (Northern Ireland), The		S.1311	2009-04-01	
-1282	Health and Social Care Information Centre		S.1311	2005-04-01	
-4836	Health and Safety Executive for Northern Ireland		S.1311		
-1281	Health and Safety Executive		S.1311		
-4835	Health and Safety Commission		S.1311		2008-04-01
-4834	Health and Safety Agency for Northern Ireland		S.1311		
-4833	Health and Care Professions Council		S.1311	2012-08-01	
-4832	Health Advisory Service		S.1311		
-4826	Haverfordwest Port		S.1313		
-4825	Haverfordwest Aerodrome		S.1313		
-1280	Havant Borough Council		S.1313		
-4821	Hatfield - (s NTC)		S.1311		
-1279	Hastings Borough Council		S.1313		
-4816	Harwich Haven Authority		S.11001		
-1278	Hartlepool Borough Council		S.1313		
-1277	Hart District Council		S.1313		
-1276	Harrogate Borough Council		S.1313		
-1275	Harlow District Council		S.1313		
-4805	Harlow - (s NTC)		S.1311		
-1274	Harborough District Council		S.1313		
-4796	Hannah Research Institute		S.1311		2006-04-01
-1273	Hampshire County Council		S.1313		
-4793	Hampshire & Isle of Wight Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1272	Hambleton District Council		S.1313		
-4788	Halton Borough Transport		S.11001		
-1271	Halton Borough Council		S.1313		
-4781	Hackney Homes Ltd		S.11001		
-4778	H&F Homes Ltd		S.11001		2011-04-01
-4777	Gyrfa Cymru Gogledd Orllewin Cyfyngedig		S.1311	2013-04-01	
-4775	Gwynedd County Council		S.1313		
-4774	Gwent Careers Service Partnership		S.1311	2013-04-01	
-1270	Guildford Borough Council		S.1313		
-4765	Guaranteed Export Financing Corporation (GEFCo) *		S.1311		
-4764	Guaranteed Export Finance Corporation PLC (GEFCo)		S.12601		
-4761	Groundwork UK		S.1311		
-4760	Groundwork Trusts (En Bloc)		S.1311		
-1269	Groceries Code Adjudicator		S.1311	2013-06-01	
-4757	Greenwich Hospital		S.11001		
-4750	Green Dragon AudioVisual Ltd - (s Remploy Ltd)		S.11001		
-4749	Greater Nottingham Rapid Transit Ltd		S.1313		
-4748	Greater Manchester Waste Disposal Authority		S.1313		
-4747	Greater Manchester Sites Ltd		S.1313		
-4746	Greater Manchester Passenger Transport Executive - (s PTE)		S.1313		1998-04-01
-4745	Greater Manchester Passenger Transport Executive		S.11001		
-4744	Greater Manchester Lieutenancy		S.1313		
-4743	Greater Manchester Integrated Transport Authority		S.1313		
-4742	Greater Manchester Combined Authority		S.1313		
-4741	Greater London Magistrates Court Authority		S.1313		2005-04-01
-1268	Greater London Authority		S.1313		
-4740	Great Yarmouth Transport Ltd		S.11001		2002-05-01
-1267	Great Yarmouth Borough Council		S.1313		
-4736	Great North Eastern Railway (GNER) Ltd		S.11001		2007-12-01
-1266	Gravesham Borough Council		S.1313		
-4732	Grant Maintained Schools (En Bloc)		S.1311		
-4731	Granite Mortgages 04-3 plc		S.12501		
-4730	Granite Mortgages 04-2 plc		S.12501		
-4729	Granite Mortgages 04-1 plc		S.12501		
-4728	Granite Mortgages 03-3 plc		S.12501		
-4727	Granite Mortgages 03-2 plc		S.12501		
-4726	Granite Mortgages 03-1 plc		S.12501		
-4725	Granite Mortgages 02-2 plc		S.12501		
-4724	Granite Mortgages 02-1 plc		S.12501		
-4723	Granite Mortgages 01-2 plc		S.12501		
-4722	Granite Mortgages 01-1 plc		S.12501		
-4721	Granite Master Issuer plc		S.12501		
-4720	Granite Finance Funding 2 Limited		S.12501		
-4714	Grampian Regional Council Harbour		S.1313		
-4710	Government-Industry Forum on non-food uses of crops		S.1311		
-4709	Government Purchasing Agency (Northern Ireland)		S.1311		
-4708	Government Property Lawyers		S.1311		
-1265	Government Procurement Service		S.11001	2011-07-01	
-1264	Government Legal Department		S.1311		
-4707	Government Hospitality Fund Advisory Committee for the Purchase of Wine		S.1311		2010-10-01
-1263	Government Equalities Office		S.1311		2011-04-01
-1262	Government Communications Headquarters		S.1311		
-1261	Government Car and Despatch Agency		S.1311		2012-10-01
-4706	Government Annuities Investment Fund		S.1311		
-1260	Government Actuary's Department		S.1311		
-1259	Gosport Borough Council		S.1313		
-1258	Gloucestershire County Council		S.1313		
-4692	Gloucestershire Airport Ltd		S.11001		
-4691	Gloucester/Cheltenham (Staverton) Aerodrome		S.1313		
-1257	Gloucester City Council		S.1313		
-4688	Globe Enterprises Ltd		S.1313		
-4686	Glenforsa Aerodrome		S.1313		
-4680	Glasgow Prestwick Airport Limited		S.11001	2013-11-22	
-1872	Glasgow City Council		S.1313		
-4678	Glasgow 2014 Ltd		S.1311	2007-06-01	
-4669	Genetics and Insurance Committee		S.1311		
-4667	General Teaching Council for Wales		S.1311	1905-06-22	
-4666	General Teaching Council for Scotland		S.1311	1905-06-24	
-4665	General Teaching Council for Northern Ireland		S.1311	1905-06-24	
-1256	General Teaching Council for England		S.1311		2012-04-01
-1255	General Social Care Council		S.1311		2012-10-01
-4664	General Register Office for Scotland (GROS)		S.1311		2011-04-01
-4663	General Lighthouse Fund		S.1311	1905-04-29	
-1254	General Consumer Council for Northern Ireland		S.1311		
-4662	General Commissioners of Income Tax (GCIT)		S.1311		
-4661	Gene Therapy Advisory Committee		S.1311		
-4659	Geffrye Museum Trust Ltd		S.1311		
-1253	Gedling Borough Council		S.1313		
-4656	Gateshead Housing Company		S.11001		
-4655	Gateshead Council		S.1313		
-1789	Gas and Electricity Consumers' Council (energywatch)		S.1311		2008-04-01
-4653	Gardenstown Harbour		S.11001		2015-12-02
-1252	Gangmasters Licensing Authority		S.1311	2005-04-01	
-1251	Gaming Board for Great Britain		S.1311		
-1250	Gambling Commission		S.1311		
-4650	Galleon Ltd (s BBCW)		S.11001		2013-05-01
-1249	Fylde Borough Council		S.1313		
-1876	Further Education Funding Council for Wales		S.1311		
-4645	Further Education Funding Council (FEFC)		S.1311		
-4644	Further Education Corporations in England (En Bloc)		S.1311		2012-04-01
-4643	Furness Enterprise Ltd		S.1313		
-4642	Funding Agency for Schools		S.1311		
-4640	Fuel Cells Advisory Panel		S.1311		
-4632	Free Schools (En Bloc)		S.1311		
-4631	Fraserburgh Harbour		S.11001		2015-12-02
-4625	Foyle, Carlingford and Irish Lights Commission		S.1311	1999-12-01	
-4624	Foyle Fisheries Commission		S.1311		
-4622	Foundation Schools (and Foundation Special Schools) (En Bloc)		S.1313	2010-05-01	
-4615	Forth Road Bridge Joint Board		S.11001		2002-04-01
-4613	Forth Estuary Transport Authority		S.1311	2008-02-01	2015-04-30
-1248	Forestry Commission		S.1311		
-1247	Forest Research		S.1311		
-1246	Forest of Dean District Council		S.1313		
-1245	Forest Heath District Council		S.1313		
-4609	Forest Enterprise Wales		S.11001		2004-04-01
-4608	Forest Enterprise Scotland		S.11001		
-1803	Forest Enterprise England		S.11001		
-4607	Foresight Steering Group		S.1311		2001-04-01
-4606	Forensic Science Service Northern Ireland		S.1311		
-1244	Forensic Science Service		S.11001		
-1243	Foreign Compensation Commission		S.1311		2013-03-01
-1242	Foreign & Commonwealth Office		S.1311		
-4603	Football Taskforce		S.1311		
-1241	Football Licensing Authority		S.1311		
-4602	Food Standards Scotland		S.1311	2015-04-01	
-1240	Food Standards Agency		S.1311		
-1239	Food from Britain		S.1.311		
-1880	Food and Environment Research Agency (FERA)		S.1311		2015-03-31
-4601	Food Advisory Committee		S.1311		
-4600	Folkestone Sports Centre Trust Ltd		S.1313		
-4599	Fluorochem Ltd - (s BNFL F2 Ltd)		S.11001		
-1238	Flintshire County Council		S.1313		
-4597	Flexibus Ltd - (s NITHC)		S.11001		2008-09-01
-1237	Fleet Air Arm Museum		S.11001		
-4596	Flamborough (North Sea Landing) Harbour Commissioners		S.11001		
-4591	Fisheries Research Services		S.1311		2009-04-01
-4590	Fisheries Research Agency		S.1311		
-1236	Fisheries Conservancy Board for Northern Ireland		S.1311		2009-06-01
-4588	First Rate Exchange Services Limited		S.12601	1905-06-24	
-4587	First Rate Exchange Services Holdings Limited		S.12601	1905-06-24	
-4584	First Choice Homes Oldham Ltd		S.11001		2011-02-01
-4582	Firesmart Ltd - (s LDDC)		S.11001		
-1235	Firebuy		S.1311		2011-04-01
-1234	Firearms Consultative Committee		S.1311		
-1233	Fire Service College		S.11001		
-1232	Fire Authority for Northern Ireland		S.1311		2006-07-01
-4581	Fire and Rescue Services (Scotland) (En Bloc)		S.1313		2013-04-01
-4580	Fire and Rescue Services (England and Wales) (En Bloc)		S.1313		
-4579	Fire and Rescue Authorities (Scotland) (En Bloc)		S.1313		2013-04-01
-4578	Fire and Rescue Authorities (En Bloc)		S.1313	2004-10-01	
-4577	Fire and Civil Defence Authorities (En Bloc)		S.1313		
-4573	Financial Services Tribunal		S.1311		
-4572	Financial Services Compensation Scheme		S.1311		
-4571	Financial Services Authority		S.12601		2013-04-01
-4570	Financial Services and Markets Appeal Tribunal		S.1311		
-4569	Financial Reporting Council, The		S.1311		
-4568	Financial Reporting Advisory Board		S.1311		
-4567	Financial Ombudsman Service		S.12601		
-1231	Financial Conduct Authority		S.12601	2013-04-01	
-4566	Finance Wales Plc		S.1311		
-4565	Finance Wales Investments Ltd		S.12501		
-4564	Finance Wales Investments (2) Ltd		S.12501		
-4563	FilmFour Ltd - (s C4)		S.11001		
-4562	Fife Regional Council Harbour		S.1313		
-4560	Fife Council		S.1313		
-4559	Fieldwealth Ltd - (s LDDC)		S.11001		
-4557	FHS Appeals Authority		S.1311		
-4555	Fermanagh and Omagh District Council		S.1313		
-1230	Fenland District Council		S.1313		
-4551	Fellside Heat and Power Ltd (s. BNG / BNFL)		S.11001		
-4549	FE Improvement Ltd		S.1311		2008-06-01
-1229	FCO Services		S.11001	2006-04-01	
-4546	Farm Animal Welfare Council		S.1311		2011-03-01
-1228	Fareham Borough Council		S.1313		
-1227	Family Procedure Rule Committee		S.1311		
-4545	Family Practitioner Committees		S.1311		
-4539	Family Health Services Appeal Authority (Tribunal)		S.1311		2010-01-01
-1226	Family Health Services Appeal Authority		S.1311		2005-04-01
-4538	Falmouth Harbour Commissioners		S.11001		
-4537	Falkirk Council		S.1313		
-4532	Fairfields Art Centre Trust		S.1313		
-4529	Fair Employment Tribunal		S.1311		
-4528	Fair Employment Commission for Northern Ireland		S.1311		
-4526	F2 Chemicals Pension Trustee Co. Ltd (s BNFL Fl Ltd)		S.11001		
-4525	F2 Chemicals Ltd - (s BNFL)		S.11001		
-4524	Eyemouth Harbour		S.11001		2015-12-02
-4522	Extra Parliamentary Panel		S.1311		
-1225	Export Guarantees Advisory Council		S.1311		
-4521	Export Credits Guarantee Department		S.12		
-4520	Export Action Group for Building Materials		S.1311		
-4519	Expert Panel on Air Quality Standards		S.1311		
-4518	Expert Group on Vitamins and Minerals		S.1311		
-4517	Expert Group on Cryptosporidium in Water Supplies		S.1311		
-4516	Expert Advisory Group on AIDS		S.1311		
-1224	Exmoor National Park Authority		S.1313	1996-06-01	
-1223	Exeter City Council		S.1313		
-4513	Exeter and Devon Airport Ltd		S.11001		
-4512	Exchange Equalisation Account		S.1311		
-4504	Eurostar (UK) Ltd		S.11001		2010-09-01
-4503	European Channel Management Ltd (s BBCW)		S.11001		
-4502	European Channel Broadcasting Ltd (s BBCW)		S.11001		
-4501	Euro-Hub (Birmingham)		S.1313		
-4500	Ethnic Minority Business Forum		S.1311		
-1222	Essex County Council		S.1313		
-4498	Essex Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1221	Erewash Borough Council		S.1313		
-1220	Equality Commission for Northern Ireland		S.1311		
-1219	Equality and Human Rights Commission		S.1311		
-1218	Equality 2025		S.1311	2006-12-01	
-1771	Equal Opportunities Commission for Northern Ireland		S.1311		
-1217	Epsom and Ewell Borough Council		S.1313		
-1216	Epping Forest District Council		S.1313		
-1215	Environment and Heritage Service		S.1311		2008-07-01
-1214	Environment Agency		S.1311		
-1213	Enterprise Ulster		S.1311		
-4494	Enterprise South Devon		S.1313		
-4493	Enrichment Investments Limited		S.1311	2009-12-01	
-4492	Enrichment Holdings Limited		S.1311	2008-03-01	
-4491	Enniskillen Aerodrome		S.1313		
-4489	English Tourism Council		S.1311		
-4487	English Partnerships (LP) Limited		S.1311		
-1212	English Nature		S.1311		
-4486	English National Board for Nursing, Midwifery and Health Visiting		S.1311		
-1825	English Institute for Sport, The		S.1311	2002-04-01	
-4485	England Marketing Advisory Board		S.1311		
-1211	Engineering Construction Industry Training Board		S.1311		
-1712	Engineering and Physical Sciences Research Council, The		S.1311		
-4484	Enfield Homes Ltd		S.11001		
-4483	Energy Sales and Trading Ltd (s. BNFL)		S.11001		2007-04-01
-4482	Energy Advisory Panel		S.1311		
-4478	Employment Tribunals Service		S.1311		2006-04-01
-4477	Employment Service		S.1311		2002-04-01
-1210	Elmbridge Borough Council		S.1313		
-4469	Electricity Settlements Company Ltd		S.1311	2014-08-01	
-4468	Electricity Producers Insurance Co. Ltd		S.11001		
-4467	Electricity Council		S.1311		
-1871	Electoral Commission		S.1311		
-4460	Eileen Trust		S.1311		
-4455	Education Transfer Council (ETC)		S.1311		
-4454	Education Scotland		S.1311	2011-04-01	
-4453	Education Leeds Ltd		S.1313		
-1209	Education Funding Agency		S.1311	2012-04-01	
-4452	Education Action Fora		S.1313		
-4451	Edinburgh Tours Ltd		S.11001		
-4450	Edinburgh International Conference Centre Ltd		S.1313		
-4449	Edinburgh City Council		S.1313		
-1208	Eden District Council		S.1313		
-4447	Eday Aerodrome		S.1313		
-4446	Economic Research Institute of Northern Ireland		S.1311		
-1722	Economic and Social Research Council, The		S.1311		
-4443	Eblex Ltd		S.1311		
-1207	Eastleigh Borough Council		S.1313		
-4439	Eastern Shires Purchasing Organisation		S.11001		
-4438	Eastern Region: Electricity Consumers’ Committee		S.1311		
-1859	Eastern Health and Personal Social Services Board		S.1311		
-4437	Eastbourne Homes Ltd		S.11001		
-4436	Eastbourne Buses Ltd		S.11001		2008-12-01
-1206	Eastbourne Borough Council		S.1313		
-1205	East Sussex County Council		S.1313		
-1204	East Staffordshire Borough Council		S.1313		
-1203	East Riding of Yorkshire Council		S.1313		
-1838	East Renfrewshire Council		S.1313		
-4433	East of Scotland Water Authority		S.11001		
-4432	East of England International Ltd		S.1311		2012-06-21
-1202	East of England Development Agency		S.1311		2012-07-01
-1201	East Northamptonshire Council		S.1313		
-4431	East North East Homes Leeds		S.11001		
-4430	East Midlands Region: Electricity Consumers Committee		S.1311		
-4429	East Midlands International Airport		S.11001		
-1740	East Midlands Development Agency		S.1311		2012-07-01
-4427	East Midlands Cultural Consortium		S.1311		2010-09-01
-4426	East Midlands Airport Property Investments (Offices) Ltd		S.11001/3	2013-02-01	
-4425	East Midlands Airport Property Investments (Industrial) Ltd		S.11001/3	2013-02-01	
-4424	East Midlands Airport Property Investments (Hotels) Ltd		S.11001/3	2013-02-01	
-4423	East Midlands Airport Nottingham Derby Leicester Ltd		S.11001/3	2013-02-01	
-4422	East Midlands Airport (s MA)		S.11001/3	2013-02-01	
-1870	East Lothian Council		S.1313		
-4420	East London Waste Authority		S.1313	1986-01-01	
-1200	East Lindsey District Council		S.1313		
-4419	East Lancashire Light Railway Trust		S.1313		
-4417	East Kent Housing		S.11001	2011-04-01	
-1199	East Hertfordshire District Council		S.1313		
-1198	East Hampshire District Council		S.1313		
-4414	East Durham Homes Ltd		S.11001		
-4412	East Dunbartonshire Municipal Bank Ltd		S.12501		
-1834	East Dunbartonshire Council		S.1313		
-1197	East Dorset District Council		S.1313		
-1196	East Devon District Council		S.1313		
-4411	East Coast Main Line Company Ltd		S.11001		2015-03-01
-1195	East Cambridgeshire District Council		S.1313		
-1865	East Ayrshire Council		S.1313		
-4407	Ealing Homes Ltd		S.11001		2012-11-01
-4404	Durham Tees Valley Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1194	Durham County Council		S.1313		
-4401	Dunstaffnage Marine Laboratory		S.1311		
-1877	Dundee City Council		S.1313		
-4398	Dundee Aerodrome		S.1313		2007-12-01
-4396	Dunbar Port		S.1313		
-4395	Dunbar Harbour		S.11001		2015-12-02
-4394	Dumfries and Galloway Regional Council Harbour		S.1313		
-1830	Dumfries and Galloway Council		S.1313		
-4392	Duke of York’s Military School		S.1311		2007-04-01
-1193	Dudley Metropolitan Borough Council		S.1313		
-1192	Driving Standards Agency		S.11001		
-1734	Driver and Vehicle Licensing Agency (DVLA)		S.1311		
-4387	Driver & Vehicle Agency (Northern Ireland)		S.11001		
-4384	Drainage Council for Northern Ireland		S.1311		
-4383	Dover Harbour Board		S.11001		
-1191	Dover District Council		S.1313		
-4382	Dounreay Site Restoration Limited		S.1311	2008-04-01	
-4381	Dorset, Devon & Cornwall Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1190	Dorset County Council		S.1313		
-4380	Dornoch Aerodrome		S.1313		
-4379	Dorneywood Trust		S.1311		
-1189	Doncaster Metropolitan Borough Council		S.1313		
-4375	Donations and Bequests (to government)		S.1311		
-4374	Dominican Playgroup		S.1313		
-4373	Domestic Coal Consumers' Council		S.1311		
-4371	Dolerite Funding No.2 plc		S.12501		
-4370	Dolerite Funding No.1 plc		S.12501		
-4369	Doctors’ and Dentists’ Review Body		S.1311		
-4368	Docklands Light Railway Ltd (s.TfL)		S.11001		
-4367	DoA Ltd		S.1311		2012-07-01
-4365	District Councils		S.1313		
-4364	Distinction and Meritorious Service Awards Committee		S.1311		
-1188	Disposal Services Agency		S.1311		2007-04-01
-1187	Disclosure and Barring Service		S.1311	2012-12-01	
-1729	Disabled Persons Transport Advisory Committee (DPTAC)		S.1311		
-1736	Disabled People’s Employment Corporation (UK) Ltd		S.1311	2015-04-07	
-4363	Disability Rights Task Force		S.1311		
-1186	Disability Rights Commission		S.1311		
-4362	Disability Living Allowance Advisory Board for Northern Ireland		S.1311		
-4361	Disability Living Allowance Advisory Board		S.1311		2013-02-01
-4360	Disability Employment Advisory Committee		S.1311		2008-04-01
-1760	Directly Operated Railways		S.1311		
-4359	Direct Service Organisations		S.1313		
-4358	Direct Rail Services Ltd		S.11001		
-4357	Direct Line Group		S.12801		2013-09-01
-4356	Direct Labour Organisations (En Bloc)		S.1313		
-4355	Diplomatic Service Appeal Board		S.1311		2011-03-01
-4352	Diceform Ltd  - (s Remploy Ltd)		S.11001		
-4351	Diamond Light Source Limited		S.1311	2002-02-01	
-4350	Devon Waste Management Limited		S.11001		2003-12-01
-1185	Devon County Council		S.1313		
-4348	Development Initiative for Slough Housing		S.1313		
-4347	Development Board for Rural Wales		S.11001		
-4346	Development Awareness Working Group		S.1311		2001-04-01
-4345	Developing Initiatives for Support in the Community		S.11001		
-4342	Design Council (incorporating CABE)		S.1311		2011-04-01
-4335	Derry City and Strabane District Council		S.1313		
-4334	Derbyshire, Nottinghamshire, Leicestershire & Rutland Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1184	Derbyshire Dales District Council		S.1313		
-1183	Derbyshire County Council		S.1313		
-4333	Derby Homes Ltd		S.11001		
-1182	Derby City Council		S.1313		
-1733	Department of Trade and Industry (DTI)		S.1311		
-1181	Department of Health		S.1311		
-1819	Department of Energy and Climate Change (DECC)		S.1311		2016-07-14
-1180	Department for Work and Pensions		S.1311		
-4329	Department for Transport, Local Government and the Regions (DTLR)		S.1311		
-1179	Department for Transport		S.1311		
-1178	Department for International Trade		S.1311	2016-07-14	
-1177	Department for International Development		S.1311		
-1828	Department for Innovation, Universities & Skills (DIUS)		S.1311		
-1176	Department for Exiting the European Union		S.1311	2016-07-14	
-1175	Department for Environment, Food & Rural Affairs		S.1311		
-4328	Department for Employment and Skills		S.1311		
-1174	Department for Employment and Learning		S.1311		
-1173	Department for Education		S.1311		
-4327	Department for Culture, Media & Sport		S.1311		
-1730	Department for Constitutional Affairs (DCA)		S.1311		2007-05-01
-1172	Department for Communities and Local Government		S.1311		
-1719	Department for Children, Schools and Families (DCSF)		S.1311		
-1807	Department for Business, Innovation and Skills		S.1311		2016-07-14
-1823	Department for Business, Enterprise & Regulatory Reform (BERR)		S.1311		
-1798	Department for Business, Energy and Industrial Strategy		S.1311	2016-07-14	
-1171	Dental Vocational Training Authority		S.1311		
-4326	Dental Rates Study Group		S.1311		
-1170	Dental Practice Board		S.1311		
-4324	Denehurst Park (Rochdale) Ltd		S.1313		
-1169	Denbighshire County Council		S.1313		
-4322	Defence, Clothing and Textiles Agency		S.1311		2010-07-01
-1168	Defence Vetting Agency		S.1311		2011-10-01
-4321	Defence Transport and Movement Executive		S.1311		2007-04-01
-1167	Defence Support Group		S.11001		
-1166	Defence Storage and Distribution Agency		S.1311		2010-07-01
-4320	Defence Secondary Care Agency		S.1311		2003-04-01
-1165	Defence Scientific Advisory Council		S.1311		
-1751	Defence Science and Technology Laboratory (The) (DSTL)		S.11001		
-1164	Defence Procurement Agency		S.1311		2007-04-01
-4319	Defence Postal and Courier Services Agency		S.1311		
-1163	Defence Nuclear Safety Committee		S.1311		
-4318	Defence Medical Training Organisation		S.1311		2008-04-01
-1853	Defence Intelligence and Security Agency		S.1311		2005-04-01
-4317	Defence Housing Executive		S.1311		2004-04-01
-4316	Defence Geographical and Imaging Intelligence Agency		S.1311		2005-04-01
-4315	Defence Evaluation and Research Agency		S.11001		2001-07-01
-4314	Defence Estates Organisation		S.1311		
-1162	Defence Estates		S.1311		2007-04-01
-4313	Defence Dental Agency		S.1311		2005-04-01
-1787	Defence Communications Services Agency		S.1311		2007-04-01
-4312	Defence Codification Agency		S.1311		
-1161	Defence Bills Agency		S.1311		2007-04-01
-1160	Defence Aviation Repair Agency		S.11001		
-4311	Defence Animal Centre		S.1311		
-1159	Defence Analytical Services Agency		S.1311		2008-04-01
-4310	Deer Commission for Scotland		S.1311		2011-04-01
-4309	Debt Management Account		S.1311		
-4305	David MacBrayne Ltd		S.1311	2006-07-01	
-4304	David MacBrayne HR (UK) Ltd		S.1311	2007-11-01	
-1158	Daventry District Council		S.1313		
-4301	Darwin Advisory Committee		S.1311		
-4300	Dartmoor Steering Group and Working Party		S.1311		2006-04-01
-1157	Dartmoor National Park Authority		S.1313	1996-06-01	
-1156	Dartford Borough Council		S.1313		
-1155	Darlington Borough Council		S.1313		
-4292	Dale and Valley Homes Ltd		S.11001		
-4290	DairyCo Ltd		S.1311		
-4289	Dairy Produce Quota Tribunal		S.1311		
-4288	Dacorum Council		S.1313		
-4283	Cwmbran - (s NTC)		S.1311		
-4282	Cwm Taf Health Board		S.1311	2009-06-01	
-4280	Customer Service Committees (OFWAT)		S.1311		
-4276	Cumbria Waste Disposal		S.1313		
-1154	Cumbria County Council		S.1313		
-4275	Cumbria and Lancashire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-4273	Cumbernauld Development Corporation		S.11001		
-4272	Culture North East (North East Cultural Consortium)		S.1311		2010-09-01
-4270	CTRL Section 1 Finance plc		S.1311	2009-06-01	
-4269	CTRL (UK) Ltd		S.11001		2010-11-01
-4267	Cruden Bay Harbour		S.11001		2015-12-02
-1153	Crown Prosecution Service		S.1311		
-4265	Crown Office, Scotland		S.1311		
-4264	Crown Estate Paving Commission		S.1313		
-4263	Crown Estate		S.11001		
-4262	Crown Courts (En Bloc)		S.1311		
-4261	Crown Court Rule Committee		S.1311		2012-09-01
-1152	Crown Agents Holding and Realisation Board		S.11001		
-4260	Crown Agents for Overseas Governments and Administrations Ltd (known as Crown Agents)		S.11001		
-4259	Crossrail Limited		S.1313		
-4258	Cross London Rail Links Ltd		S.1311		
-4253	Cromarty Harbour		S.11001		2015-12-02
-4252	Cromarty Firth		S.11001		2015-12-02
-4251	Crofting Commission (formerly Crofter's Commission)		S.1311		
-1151	Criminal Records Bureau		S.1311		2003-08-01
-1150	Criminal Procedure Rule Committee		S.1311	2004-01-01	
-1777	Criminal Justice Inspection Northern Ireland / the Chief Inspector of Criminal Justice in Northern Ireland		S.1311		
-1827	Criminal Injuries Compensation Board		S.1311		
-1149	Criminal Injuries Compensation Authority		S.1311		
-1731	Criminal Injuries Compensation Appeals Panel (CICAP)		S.1311		2006-04-01
-1148	Criminal Cases Review Commission		S.1311		
-4249	Crime Prevention Agency Board		S.1311		
-4248	Crime Concern, Marks and Spencer, Groundwork Partnership (t/a Youth Works) (The)		S.1311		
-1147	Creative Scotland		S.1311	2010-07-01	
-1146	Crawley Borough Council		S.1313		
-1145	Craven District Council		S.1313		
-4242	Cowal Ferries Ltd		S.1311	2007-04-01	
-1144	Coventry City Council		S.1313		
-4240	Coventry (Basington) Aerodrome		S.1313		
-1143	Covent Garden Market Authority		S.11001		
-4237	Coutts & Co		S.12201		
-4236	Court Service, The		S.1311		2005-04-01
-4235	Court Funds Investment Account		S.1311		
-4234	County Schools (En Bloc)		S.1313		
-4232	County Durham Development Co Ltd		S.1313		
-4231	County Courts		S.1311		
-4230	County Court Rule Committee		S.1311		
-4229	County Councils (En Bloc)		S.1313		
-4228	Countryside Council for Wales		S.1311		2013-04-01
-1142	Countryside Agency		S.1311		2006-10-01
-1141	Counter Fraud and Security Management Service		S.1311		
-1140	Council on Tribunals		S.1311		
-1139	Council of the Isles of Scilly		S.1313		
-4226	Council of Reserve Forces and Cadet Associations / Reserve Forces and Cadet Associations		S.1311		
-4225	Council for the Regulation of Healthcare Professionals		S.1311		
-1714	Council for the Central Laboratory of the Research Councils (CCLRC)		S.1311		
-1138	Council for Science and Technology		S.1311		
-4224	Council for Professions Supplementary to Medicine, the		S.1311		
-4223	Council for Nature Conservation and the Countryside		S.1311		
-4222	Council for National Academic Awards		S.1311		
-1137	Council for Healthcare Regulatory Excellence		S.1311		
-1136	Council for Catholic Maintained Schools		S.1311		
-1135	Cotswold District Council		S.1313		
-4217	Coroners		S.1313		
-4215	Cornwall Housing Ltd		S.11001	2010-04-01	
-1134	Cornwall Council		S.1313		
-4213	Cornwall Airport		S.1313		
-1133	Corby Borough Council		S.1313		
-4208	Corby - (s NTC)		S.1311		
-4207	Copyright Tribunal, The		S.1311		
-1132	Copeland Borough Council		S.1313		
-1131	Conwy County Borough Council		S.1313		
-4198	Conversion Loan Redemption Account		S.1311		
-4196	Contributions Agency		S.1311		
-4195	Contracts Rights Renewal Adjudicator		S.1311	2003-12-01	
-4193	Contingencies Fund		S.1311		
-4192	Consumers’ Committee for Great Britain under the Agricultural Marketing Act 1958		S.1311		
-4191	Consumer Panel		S.1311		
-4190	Consumer Focus		S.1311	2008-04-01	
-4189	Consumer Financial Education Body Ltd		S.1311	2010-04-01	
-1130	Consumer Council for Water		S.1311		
-1757	Consumer Council for Postal Services (Postwatch)		S.1311		2008-04-01
-4188	Consumer Communications for England (CCE)		S.1311		
-4187	Consultative Board on Badgers and Bovine Tuberculosis		S.1311		
-4186	Construction Service		S.1311		
-4185	Construction Industry Training Board, The		S.1311		
-1721	Construction Industry Training Board (NI)		S.1311		
-4184	Construction Industry Advisory Council (Northern Ireland)		S.1311		
-4183	Consolidated Fund		S.1311		
-4182	Consignia (Customer Management) Limited		S.11001		
-4181	Conservation Board for the Cotswolds Area of Outstanding Natural Beauty		S.1313	2004-12-01	
-4180	Conservation Board for the Chilterns Area of Outstanding Natural Beauty		S.1313	2004-12-01	
-4176	Compost Development Venture (CDV) Ltd		S.1313		
-1129	Competition Service		S.1311		
-1128	Competition Commission		S.1311		
-1127	Competition Appeal Tribunal		S.1311		
-1126	Competition and Markets Authority		S.1311	2013-10-01	
-4175	Compensation Agency (Northern Ireland)		S.1311		
-1125	Companies House		S.11001		
-4173	Community Schools (En Bloc)		S.1313	1999-11-01	
-4172	Community Safety Glasgow		S.1313	2006-10-01	
-4171	Community Learning Scotland		S.1311		
-4169	Community Health Councils (Wales) Board		S.1311		
-4168	Community Health Councils (Wales)		S.1311		
-4167	Community Health Councils (En Bloc)		S.1311		2003-12-01
-1124	Community Fund		S.1311		
-1123	Community Development Foundation		S.1311		
-4165	Community Councils (Wales) (En Bloc)		S.1313	1905-05-25	
-4164	Community Councils (Scotland) (En Bloc)		S.1313	1905-05-26	
-4163	Community and Safety Services Limited		S.11001	2009-07-28	
-4162	Communities Scotland		S.1311		2008-04-01
-4161	Communications for Business		S.1311		
-4160	Commonwealth War Graves Commission		S.1311		
-1122	Commonwealth Scholarship Commission in the UK		S.1311		
-4159	Commonwealth Parliamentary Association (UK) Branch		S.1311	2002-12-01	
-4158	Commonwealth Development Corporation		S.12		
-4157	Commons Commissioners		S.1311		
-4155	Common Services Agency of the Scottish Health Service (NHS National Services Scotland Board)		S.1311		
-4154	Committees for the Employment of Disabled People		S.1311		
-1121	Committee on Toxicity of Chemicals in food, Consumer Products and the Environment		S.1311		
-4153	Committee on the Safety of Medicines		S.1311		
-4152	Committee on the Medical Effects of Air Pollutants (DH)		S.1311		
-1120	Committee on Standards in Public Life		S.1311		
-4151	Committee on Products and Processes for use in Public Water Supply		S.1311		
-1119	Committee on Mutagenicity of Chemicals in Food, Consumer Products and the Environment		S.1311		
-4150	Committee on Medical Aspects of Radiation in the Environment		S.1311		
-4149	Committee on Medical Aspects of Food and Nutrition Policy		S.1311		
-1118	Committee on Climate Change		S.1311		
-4148	Committee on Carcinogenicity of Chemicals in Food, Consumer Products and the Environment		S.1311		
-4147	Committee on Appeals Criteria and Miscarriages of Justice		S.1311		
-4146	Committee on Agricultural Valuation		S.1311		
-4145	Committee of Investigation for Great Britain		S.1311		
-4144	Committee for Monitoring Agreements On Tobacco Advertising Sponsorship		S.1311		
-4143	Commissioners of Taxes for the City of London		S.1313		
-4142	Commissioners of Irish Lights, The		S.1311	1905-04-29	
-4141	Commissioner of the Metropolis (Metropolitan Police Force)		S.1313	2012-01-01	
-1881	Commissioner for the Rights of Trade Union Members		S.1311		
-1851	Commissioner for Protection against Unlawful Industrial Action		S.1311		
-4140	Commissioner for Ethical Standards in Public Life in Scotland		S.1311	2011-04-01	
-4139	Commission for Victims and Survivors		S.1311	2008-05-01	
-4138	Commission for the New Economy Ltd		S.1313		
-1768	Commission for Social Care Inspection for England (CSCI)		S.1311		2009-03-01
-1117	Commission for Rural Communities		S.1311		
-1116	Commission for Patient and Public Involvement in Health		S.1311		2008-06-01
-4137	Commission for New Towns		S.1311		
-4136	Commission for Local Administration in Wales		S.1311		
-4135	Commission for Local Administration		S.1311		
-4134	Commission for Judicial Appointments (Scotland)		S.1311		
-4133	Commission for Integrated Transport		S.1311		
-1115	Commission for Health Improvement		S.1311		
-1715	Commission for Architecture and the Built Environment		S.1311		2011-04-01
-1836	Comhaire nan Eilean Siar Council		S.1313		
-4132	Combined Courts (En Bloc)		S.1311		
-4127	Collieston Harbour		S.11001		2015-12-02
-4126	Colleges of Further Education (Scotland) (En Bloc)		S.1311	1993-04-01	
-4125	College of Policing		S.1311	2013-02-01	
-4124	College of Arms		S.1311		
-4123	Coll Aerodrome		S.1313		
-4122	Coleraine Harbour Commissioners		S.11001		
-4121	Coleraine District Policing Partnership		S.1313		
-4120	Colchester Port		S.1313		
-4119	Colchester Borough Homes Ltd		S.11001		
-1114	Colchester Borough Council		S.1313		
-4115	Coastguard		S.1311		
-4112	Coal Industry Patents Ltd - (s BCC)		S.11001		
-4111	Coal Industry Estates Ltd - (s BCC)		S.11001		
-4110	Coal Developments (Queensland) Ltd - (s BCC)		S.11001		
-1113	Coal Authority		S.1311		
-4109	CNC Building Control Consultancy Joint Committee		S.11001		
-4107	Clydebank Municipal Bank Ltd		S.12501		
-4103	Clothing and Industry Training Boards (NI)		S.1311		
-4102	Clothing and Allied Products Industry Training Board		S.1311		
-4099	Clinical Standards Board for Scotland (The)		S.1311		2003-01-01
-4098	Clinical Standards Advisory Group		S.1311		
-4097	Clinical Imaging Services Advisory Committee		S.1311		
-4096	Clinical Engineering and Medical Physics Services Advisory Committee		S.1311		
-4095	Clinical Commissioning Groups (En Bloc)		S.1311	2013-04-01	
-4094	CLIK (Central Laboratory Innovation and Knowledge Transfer Co.Ltd)		S.11001		
-1843	Clackmannanshire Council		S.1313		
-4089	Civil Service Occupational Health and Safety Agency		S.1311		
-1112	Civil Service Commission		S.1311	2010-11-01	
-4088	Civil Service Arbitration Tribunal		S.1311		
-4087	Civil Service Appeal Board		S.1311		
-4086	Civil Service Annuities Assurance Society, The		S.12801		2003-05-01
-1111	Civil Procedure Rule Committee		S.1311		
-1776	Civil Nuclear Police Authority		S.1311	2005-04-01	
-1110	Civil Justice Council		S.1311		
-4085	Civil Aviation Authority International Ltd (CAA International Ltd)		S.11001	2000-11-01	
-1752	Civil Aviation Authority (CAA)		S.11001		
-4084	CityWest Homes Ltd		S.11001		
-4083	Citybus Ltd - (s NITHC)		S.11001		
-4080	City Technology Colleges (En Bloc)		S.1311	2010-05-01	
-1109	City of York Council		S.1313		
-4077	City of London Police		S.1313		
-1108	City of London Corporation		S.1313		
-1107	City of Lincoln Council		S.1313		
-4074	City of Glasgow District Council Market		S.1313		
-4072	City of Edinburgh District Council Market		S.1313		
-4071	City of Dundee District Council Launderette		S.1313		
-4070	City Colleges for the Technology of the Arts (En Bloc)		S.1311	1988-07-01	
-1759	City and County of Swansea		S.1313		
-4069	City Airport Rail Enterprises Plc		S.1313	2011-11-01	
-4068	City Airport Rail Enterprises (Holdings) Limited		S.1313	2011-11-01	
-4067	City Academies (En Bloc)		S.1311		
-4061	Churches Conservation Trust		S.1311		
-1106	Christchurch Borough Council		S.1313		
-4055	Chorley Council		S.1313		
-1105	Chiltern District Council		S.1313		
-4045	Children’s Commissioner for Wales		S.1311		
-1104	Children's Workforce Development Council		S.1311		2012-06-01
-4047	Children's Trust Boards (En Bloc)		S.1313		
-4046	Children's Panels Advisory Committee (reclassified from CG in 98q3)		S.1313		
-1831	Children and Family Court Advisory and Support Service (CAFCASS)		S.1311		
-4044	Child Support Appeal Tribunals		S.1311		
-4043	Child Support Agency		S.1311		2008-11-01
-1724	Child Maintenance and Enforcement Commission (CMEC)		S.1311		2012-08-01
-4042	Child Care Law Review Body		S.1311		
-4041	Chief Executive of Skills Funding		S.1311		
-4040	Chief Electoral Officer for Northern Ireland		S.1311		
-4039	Chichester Harbour Conservancy Board		S.11001		
-1103	Chichester District Council		S.1313		
-4036	Chevening Estate/Trust		S.1311		
-1102	Chesterfield Borough Council		S.1313		
-4034	Chester City Transport Ltd		S.11001		
-1101	Cheshire West and Chester Council		S.1313		
-1100	Cheshire East Council		S.1313		
-4032	Cheshire & Greater Manchester Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1099	Cherwell District Council		S.1313		
-4026	Chequers Trust		S.1311		
-4025	Chepstow Port		S.1313		
-4023	Cheltenham Borough Homes Ltd		S.11001		
-1098	Cheltenham Borough Council		S.1313		
-1097	Chelmsford City Council		S.1313		
-4017	Charnwood Neighbourhood Housing Ltd		S.11001		2012-11-01
-1096	Charnwood Borough Council		S.1313		
-3998	Charity Commission of Northern Ireland		S.1311	2009-06-01	
-3997	Charity Commission for England and Wales		S.1311		
-3995	Charities Advisory Committee		S.1311		
-3992	Channel Tunnel Rail Link Limited		S.11001		
-3991	Channel Four Television Corporation Ltd (C4)		S.11001		
-1820	Channel Four Television Company Ltd - (s C4)		S.11001		1992-12-01
-3990	Channel Four Learning Ltd - (s C4)		S.11001		2000-06-01
-3989	Channel Four International Ltd - (s C4)		S.11001		2007-11-01
-3987	Chancellor of the Duchy of Lancaster		S.1311		
-3986	Chamberlain of London		S.1313		
-1095	Ceredigion County Council		S.1313		
-3982	Centre House Productions Ltd (CHP) - (s BBC)		S.11001		
-3981	Centre for Management and Policy Studies		S.1311		
-1716	Centre for Environment, Fisheries and Aquaculture Science (CEFAS)		S.1311	1905-06-19	
-3980	Centre for Environment Fisheries and Aquaculture Science Technology Ltd		S.11001		
-3979	Centre for Ecology and Hydrology		S.1311		
-3978	Central Scotland Fire Board		S.1313		1905-06-27
-1094	Central Science Laboratory		S.1311		2009-04-01
-3977	Central Rail Users Consultative Committee (CRUCC)		S.1311		
-1093	Central Police Training and Development Authority		S.1311		
-1092	Central Office of Information		S.11001		2012-05-01
-3976	Central Manchester Development Corporation		S.11001		
-3975	Central Lancashire - (s NTC)		S.1311		
-3974	Central Laboratory of the Research Councils		S.1311		2007-04-01
-3973	Central Fire Brigades Advisory Council		S.1311		
-3972	Central Electricity Generating Board		S.1311		
-3971	Central Council for Education and Training in Social Work (UK)		S.1311		
-1091	Central Bedfordshire Council		S.1313		
-1090	Central Arbitration Committee		S.1311		
-1089	Central Advisory Committee on Pensions and Compensation		S.1311		
-1868	Central Advisory Committee on Justices of the Peace (Scotland)		S.1311		
-3969	Central Adjudication Services		S.1311		
-3968	Cellardyke Port		S.1313		
-3967	CEEP UK		S.1311		
-3965	CCTA- The Government Centre for Information Systems		S.1311		
-3963	Causeway Coast and Glens District Council		S.1313		
-1088	Castle Point Borough Council		S.1313		
-3953	Cart River Port (Paisley)		S.1313		
-3952	Carrick Housing Ltd		S.11001		2010-04-01
-1087	Carmarthenshire County Council		S.1313		
-3951	Carmarthen Port		S.1313		
-1086	Carlisle City Council		S.1313		
-3950	Carlisle (Crosby) Aerodrome		S.1313		
-3948	Careers Wales West - Gyrda Cymru Gorllewin Ltd		S.1311	2013-04-01	
-2600	Careers Wales Mid Glamorgan and Powys Ltd		S.1311	2013-04-01	
-2599	Careers Wales Dewis Gyrfa Ltd		S.1311	2013-04-01	
-2598	Careers Wales Cardiff and Vale Ltd		S.1311	2013-04-01	
-2597	Careers Wales Association Ltd		S.1311	2013-04-01	
-2596	Careers Scotland		S.1311		2008-04-01
-1085	Care Quality Commission		S.1311		
-2594	Care Council for Wales		S.1311		
-2591	Cardiff International Airport Ltd		S.11001	2013-03-01	
-2590	Cardiff Council		S.1313		
-2588	Cardiff City Transport Services Ltd		S.11001		
-2587	Cardiff Bay Development Corporation		S.11001		
-2586	Cardiff and Vale University Health Board		S.1311	2009-06-01	
-1084	Capital for Enterprise Limited		S.1311		2013-10-01
-1083	Canterbury City Council		S.1313		
-1082	Cannock Chase District Council		S.1313		
-2584	Canal & River Trust		S.11001	2012-07-02	
-2582	Campbeltown Port		S.1313		
-2581	Camden Mediation Service		S.1313		
-2579	Camden ITEC		S.1313		
-1081	Cambridgeshire County Council		S.1313		
-1080	Cambridge City Council		S.1313		
-2573	CalMac Ferries Ltd		S.11001		
-2571	Caledonian Maritime Assets Ltd		S.11001		
-2570	Caledonian MacBrayne Ltd		S.11001		2006-10-01
-2569	Caledonian MacBrayne (HR) UK Ltd		S.11001		2007-11-01
-1079	Calderdale Metropolitan Borough Council		S.1313		
-2566	Cairngorms National Park Authority		S.1313	2003-03-01	
-1078	Caerphilly County Borough Council		S.1313		
-2564	Caernarvon Harbour Trustees		S.11001		
-2562	Cadw (Welsh Historic Monuments)		S.1311		
-2560	CADCAM Applications Training and Support Limited		S.1313		
-1077	Cabinet Office		S.1311		
-1076	Buying Solutions		S.1311		
-2555	Buying Agency, The		S.11001		
-2550	Business and Technology Education Council		S.1311		
-2549	Business Advisory Committee on Telecommunications		S.1311		
-1075	Bury Metropolitan Borough Council		S.1313		
-2548	Burry Port		S.1313		
-2547	Burnmouth Harbour		S.11001		2015-12-02
-1074	Burnley Borough Council		S.1313		
-2546	Burghead Port		S.1313		
-2545	Building Standards Advisory Committee		S.1311		2010-07-01
-2544	Building Societies Commission		S.1311		
-1073	Building Regulations Advisory Committee		S.1311		
-2542	Bude Port		S.1313		
-1072	Buckinghamshire County Council		S.1313		
-2539	Buckie Port		S.1313		
-1071	Broxtowe Borough Council		S.1313		
-2534	Brownies Taing (Lerwick)		S.11001		2015-12-02
-1070	Bromsgrove District Council		S.1313		
-1069	Broads Authority		S.1311	1988-06-01	
-2524	Broadmoor Special Hospital Authority		S.1311		
-1068	Broadland District Council		S.1313		
-1067	Broadcasting Standards Commission		S.1311		
-2521	Broadcasting Data services Ltd		S.11001		
-2520	Broadcasting Complaints Commission		S.1311		
-2519	Broadcasters Audience Research Board Ltd (50%) (sBBCW) (Associate)		S.11001		
-2515	Brixham Port		S.1313		
-2514	British Wool Marketing Board		S.11001	1905-05-11	
-2513	British Waterways Pension Trustees Ltd - (s BWB)		S.11001		
-2512	British Waterways Board - (BWB)		S.11001		
-1066	British Transport Police Authority		S.1311		
-2511	British Transport Police (sSRA)		S.1311		
-2510	British Tourist Authority		S.1311		
-2509	British Shipbuilders		S.1311		2012-03-01
-2508	British Screen Finance Limited		S.12401	1985-05-02	
-2507	British Railways Board - (BRB)		S.11001		
-1065	British Potato Council		S.1311		
-1064	British Pharmacopoeia Commission		S.1311		
-2506	British Overseas Trade Board		S.1311		
-2505	British Nuclear Services Ltd. (s. BNG / BNFL)		S.11001		
-2504	British Nuclear Group Sellafield Ltd. (s. BNG / BNFL)		S.11001		
-2503	British Nuclear Group Project Services Ltd. (s. BNG / BNFL)		S.11001		
-2502	British Nuclear Group Ltd. (s. BNFL)		S.11001		
-2501	British Nuclear Fuels plc (BNFL)		S.11001		
-2500	British National Oil Company		S.11001		
-2499	British Museum Company Ltd		S.11001		
-1063	British Museum		S.1311		
-1062	British Library		S.1311		
-1061	British Hallmarking Council		S.1311	1905-05-27	
-2498	British Government Panel on Sustainable Development		S.1311		
-2497	British Geological Survey		S.1311		
-2496	British Gas		S.11001		
-2495	British Fuels Distributors Ltd		S.11001		2002-01-01
-2494	British Fuels (Ireland) Ltd		S.11001		2007-12-01
-2493	British Fuels		S.11001		
-1060	British Forces Post Office		S.1311		2007-04-01
-1059	British Film Institute		S.1311		
-2492	British Film Commission		S.1311		
-2491	British European Airways		S.11001		
-2490	British Energy		S.11001		
-2489	British Electricity Authority		S.11001		
-1717	British Educational Communications and Technology Agency (BECTA)		S.1311		2011-03-01
-1058	British Council		S.11001		
-2488	British Coal Staff Superannuation Scheme		S.12901	1994-10-31	
-2487	British Coal Corporation		S.11001		
-2486	British Coal (Mines)		S.11001		
-1749	British Business Bank PLC		S.1311	2013-07-01	
-2485	British Broadcasting Corporation - (BBC)		S.1311		
-2484	British Board of Agrement		S.1311		
-2483	British Association for Central & Eastern Europe		S.1311		
-2482	British Antarctic Survey		S.1311		
-2481	British Airways		S.11001		
-2480	British Airports Authority		S.11001		
-2478	Bristol, Gloucestershire, Somerset & Wiltshire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-2477	Bristol Port		S.1313		
-2476	Bristol Development Corporation		S.11001		
-1057	Bristol City Council		S.1313		
-2472	Bristol Airport		S.11001		
-2468	Brighton Buses Ltd		S.11001		
-1056	Brighton and Hove City Council		S.1313		
-2463	Bridport Port		S.1313		
-2462	Bridlington Pier and Harbour Commissioners		S.11001		
-1055	Bridgend County Borough Council		S.1313		
-1054	Brentwood Borough Council		S.1313		
-2453	Brecon Beacons National Park Authority		S.1313	1995-11-01	
-2452	Breckland Council		S.1313		
-1725	BRB (Residuary) Ltd.		S.1311		
-1053	Braintree District Council		S.1313		
-1852	Bradford Metropolitan District Council		S.1313		
-2447	Bradford Film Limited		S.1311	2010-04-01	
-2446	Bradford & Bingley plc		S.1311	2010-07-01	
-2445	Bradford & Bingley Pension Scheme		S.12901	2008-09-29	
-2443	Bracknell Forest Borough Council		S.1313		
-2442	Bracknell - (s NTC)		S.1311		
-2441	BR Property Board (s BRB)		S.11001		
-2440	BPL Holdings Ltd (Formerly Plasma Resources UK Ltd)		S.11001		2013-07-01
-2438	BPEX Ltd		S.1311		
-2437	BPE Mechanical and Electrical Engineering Consultancy		S.11001		
-2432	Bournemouth Transport Ltd		S.11001		
-2431	Bournemouth International Airport Ltd (s MA)		S.11001/3	2013-02-01	
-1052	Bournemouth Borough Council		S.1313		
-2429	Bournemouth Airport Property Investments (Offices) Ltd		S.11001/3	2013-02-01	
-2428	Bournemouth Airport Property Investments (Industrial) Ltd		S.11001/3	2013-02-01	
-1885	Boundary Committee for England		S.1311		
-1051	Boundary Commission for Scotland		S.1311		
-1050	Boundary Commission for Northern Ireland		S.1311		
-2425	Botanics Trading Company Ltd		S.11001		
-2424	Boston Port		S.1313		
-1049	Boston Borough Council		S.1313		
-1048	Borough of Poole		S.1313		
-2421	Borough of Broxbourne		S.1313		
-2419	Bòrd na Gàidhlig		S.1311		
-2418	Booth & Fisher (Motor Services) Ltd - (s SYPTE)		S.11001		1905-06-17
-2414	Bolton Council		S.1313		
-2413	Bolton at Home Ltd		S.11001		2011-03-01
-1047	Bolsover District Council		S.1313		
-2410	Bognor Regis Ltd		S.1313		
-2408	Boards of Visitors to Penal Establishments		S.1311		
-2407	Boards of Visitors and Visiting Committees (Northern Ireland)		S.1311		
-2406	BNFL Properties Limited - (s BNG / BNFL)		S.11001		
-2405	BNFL Interim Storage Ltd - (s BNFL)		S.11001		
-2404	BNFL Enterprise - (s BNG / BNFL)		S.11001		
-2403	BNFL Enrichment Ltd - (BNFL)		S.11001		2009-12-01
-2402	BNFL Engineering Ltd - (s BNFL)		S.11001		
-2401	BNFL (IP) Ltd (s. BNFL)		S.11001		
-2400	Blyth Valley Housing Ltd		S.11001		
-2399	Blyth Harbour Commissioners		S.11001		
-1046	Blaenau Gwent County Borough Council		S.1313		
-2389	Blackpool Transport Services Ltd		S.11001		
-2388	Blackpool Town Centre Forum Ltd		S.1313		
-2387	Blackpool Operating Company Ltd		S.1313		
-2386	Blackpool Grand Theatre Trust Ltd		S.1313		
-2385	Blackpool Grand Theatre Catering Ltd		S.1313		
-2384	Blackpool Grand Theatre (Arts and Entertainment) Ltd		S.1313		
-2383	Blackpool Fylde and Wyre Society for the Blind, The		S.1313		
-2381	Blackpool Council		S.1313		
-2380	Blackpool Coastal Housing Ltd		S.11001		
-2379	Blackpool Challenge Partnership Ltd		S.1313		
-2378	Blackpool Airport Ltd		S.11001		
-1045	Blackburn with Darwen Borough Council		S.1313		
-2376	Blackburn Borough Transport		S.11001		
-2375	Black Horse Ltd		S.12201		2014-03-01
-2373	Black Country Development Corporation		S.11001		
-1044	Blaby District Council		S.1313		
-2372	BIS (Postal Services Act 2011) Company Limited		S.1311	2012-02-01	
-2371	BIS (Postal Services Act 2011) B Company Limited		S.1311	2012-02-01	
-2367	Birmingham Heartlands UDC		S.11001		
-1043	Birmingham City Council		S.1313		
-2364	Birmingham BRIS		S.11001		
-2363	Birmingham Airport		S.11001		
-1713	Biotechnology and Biological Sciences Research Council (The)		S.1311		
-2359	Bio Products Laboratory Ltd		S.11001		2013-07-01
-2357	BIL Solutions Ltd - (s BNG / BNFL)		S.11001		
-2356	Biggin Hill Aerodrome		S.1313		
-2355	Big Society Trust		S.1311		2016-01-01
-2354	Big Society Foundation		S.1311		2016-01-01
-2353	Big Society Capital		S.1311		2016-01-01
-1042	BIG Lottery Fund		S.1311		
-2351	Bideford Port		S.1313		
-2347	Better Regulation Task Force		S.1311		
-2346	Betsi Cadwaladr University Health Board		S.1311	2009-06-01	
-2338	Berneslai Homes Ltd		S.11001		
-2337	Berkshire Young Musicians Trust		S.1313		
-2334	Benefits Agency		S.1311		2002-04-01
-2330	Belgrade Theatre		S.1313		
-2329	Belfast Health and Social Care Trust		S.1311	2010-04-01	
-2328	Belfast Harbour Commissioners		S.11001		
-2327	Belfast Education and Library Board		S.1311		
-2326	Belfast City Council		S.1313		
-2325	Belfast Airport		S.11001		
-2323	Beef Assurance Scheme Membership Panel		S.1311		2005-12-01
-2322	Beeches Road Community Enterprise Ltd		S.1313		
-2320	Bedfordshire, Cambridgeshire, Hertfordshire and Northamptonshire Community Rehabilitation Company (CRC)		S.1311		2015-02-01
-1041	Bedford Borough Council		S.1313		
-2316	Beaumaris Port		S.1313		
-2315	Beacon Waste Ltd		S.1313		
-2314	BCE Corporate Functions Ltd		S.11001		
-2313	BBC Worldwide Music Ltd (s BBCW)		S.11001		
-2312	BBC Worldwide Ltd (BBCW)- (s HS)		S.11001		
-2311	BBC Worldwide Channel Investment Ltd (s BBCW)		S.11001		
-2310	BBC Worldwide Americas Inc.[USA] (s BBCW)		S.11001		
-2309	BBC Worldwide (Investments) Ltd (s BBCW)		S.11001		
-2308	BBC Worldwide (Germany) GMBH [Germany] (s BBCW)		S.11001		
-2307	BBC Worldwide (France) SARL [France] (s BBCW)		S.11001		
-2306	BBC World Service Training Trust (s WS)		S.11001		
-2305	BBC World Service Television Ltd (s BBCW)		S.11001		
-1763	BBC World Service (WS)		S.1311		
-2304	BBC Radiocom Deutschland GmbH (Germany) (sWS)		S.11001		
-2303	BBC Radiocom (Slovakia) Ltd [Slovakia] (s WS)		S.11001		
-2302	BBC Radiocom (Romania) SRL [Romania] (s WS)		S.11001		
-2301	BBC Radiocom (Praha) Sro [Czech Republic] (s WS)		S.11001		
-2300	BBC Radiocom (Hungary) Ltd [Hungary] (s WS)		S.11001		
-2299	BBC Radiocom (Bulgaria) OLLC [Bulgaria] (s WS)		S.11001		
-2298	BBC Polska SP Zoo [Poland] (s WS)		S.11001		
-2297	BBC Pension Scheme		S.12901	1949-06-01	
-2296	BBC Magazines Inc. [USA] (s BBCW)		S.11001		
-2295	BBC Haymarket Exhibitions Ltd (50%) (sBBCW) (Associate)		S.11001		2014-05-23
-2294	BBC East Asia Relay Company Ltd [Hong Kong] (s WS)		S.11001		
-2293	BBC do Brazil Limitada (Brazil) (sWS)		S.11001		
-2292	BBC Commercial Holdings Limited		S.1311	2002-06-18	
-1040	Bath and North East Somerset Council		S.1313		
-1039	Bassetlaw District Council		S.1313		
-2289	Basingstoke Dial-a-Ride		S.1313		
-1038	Basingstoke and Deane Borough Council		S.1313		
-1037	Basildon Borough Council		S.1313		
-2288	Basildon - (s NTC)		S.1311		
-2287	Basic Skills Agency		S.1311		2009-05-01
-1036	Barrow-in-Furness Borough Council		S.1313		
-2282	Barnstaple Port		S.1313		
-1035	Barnsley Metropolitan Borough Council		S.1313		
-2279	Barnet Homes Ltd		S.11001		
-2277	Barbican Centre		S.1313		
-2276	Banking Department		S.121		
-2275	Bank of Scotland plc		S.12201		2014-03-01
-1034	Bank of England		S.121		
-2267	Bainsdown Ltd (s MA)		S.11001/03	2013-02-01	
-2266	Baileyfield Switch and Crossing Works		S.11001		
-1033	Babergh District Council		S.1313		
-2261	Aylesham and District Community Workshop Trust		S.1313		
-1032	Aylesbury Vale District Council		S.1313		
-2260	Aycliffe - (s NTC)		S.1311		
-2258	AWE [Atomic Weapons Establishment] Plc		S.11001		
-2257	AWE [Atomic Weapons Establishment] Management Ltd		S.11001		
-2256	Avoch Harbour		S.11001		2015-12-02
-2255	Aviation Committee		S.1311		
-2254	Averon Leisure Management Limited		S.1313		2014-04-01
-2252	Audit Scotland		S.11001		
-2251	Audit Commission Pension Scheme (The)		S.12901	2012-05-31	
-1031	Audit Commission		S.11001		2015-03-31
-2249	Auchmithie Harbour		S.11001		2015-12-02
-1030	Attorney General's Office		S.1311		
-2241	Association of Town Centre Management		S.1313		
-2240	Association of Port Health Authorities		S.1313		
-2239	Association of London Government		S.1313		
-1029	Assets Recovery Agency		S.1311		2008-04-01
-1028	Asset Protection Agency		S.1311		2012-10-01
-2235	Ashworth Hospital Authority		S.1311		
-1027	Ashford Borough Council		S.1313		
-2228	Ashfield Homes Ltd		S.11001		
-1026	Ashfield District Council		S.1313		
-2225	Ascham Homes Ltd		S.11001		
-2223	Ascension Island Personnel Ltd (50%) (sWS) (Associate)		S.11001		2004-04-01
-1025	Arun District Council		S.1313		
-1024	Arts Council of Wales		S.1311		
-1023	Arts Council of Northern Ireland		S.1311		
-1842	Arts Council of England		S.1311		
-2221	Arts Council for Wales National Lottery		S.1311		
-1720	Arts and Humanities Research Council, The		S.1311	2005-04-01	
-2220	Arts and Humanities Research Board		S.1311		2005-04-01
-2216	Army Training and Recruiting Agency		S.1311		2006-04-01
-2215	Army Technical Support Agency		S.1311		
-2214	Army Personnel Centre		S.1311		2004-04-01
-2213	Army Base Storage and Distribution Agency		S.1311		
-1748	Army Base Repair Organisation (ABRO)		S.11001		
-2211	Arms Length Management Organisations (ALMOs)		S.11001		
-1022	Armed Forces Personnel Administration Agency		S.1311		2007-04-01
-1797	Armed Forces Pay Review Body		S.1311		
-1021	Armagh Observatory and Planetarium		S.1311		
-2210	Armagh City, Banbridge and Craigavon Borough Council		S.1313		
-2205	Argyll Ferries Ltd		S.1311	2011-02-01	
-1849	Argyll and Bute Council		S.1313		
-2201	Areas of Outstanding Natural Beauty (AONB) Conservation Boards (En Bloc)		S.1313		
-2200	Ards and North Down Borough Council		S.1313		
-2197	Architecture and Design Scotland		S.1311		
-2196	Architectural Heritage Fund		S.1311		
-1020	Architects Registration Board		S.11001		
-2194	Arbroath Harbour		S.1313		
-1848		government-organisation:OT801	S.1311		2012-10-01
-2191	Apple and Pear Research Council (APRC)		S.1311		
-2190	Appeals Service		S.1311		2006-04-01
-2189	Appeal Body (DVTA)		S.1311		
-2186	Anvil Trust Ltd, The		S.1313		
-2185	Antrim and Newtownabbey Borough Council		S.1313		
-2183	Annan Harbour		S.11001		2015-12-02
-2182	Animal Welfare Advisory Committee (MOD)		S.1311		2010-07-01
-1019	Animal Procedures Committee		S.1311		
-2181	Animal Planet (Latin Am) (50%) (sBBCW) (Associate)		S.11001		
-1816	Animal Health and Veterinary Laboratories Association		S.1311		
-1018	Animal Health		S.1311		
-2180	Animal Diseases Research Association		S.1311		
-2178	Angus Council		S.1313		
-2177	Anglian Water		S.11001		
-2175	Angel Train Contracts		S.11001		
-2174	Aneurin Bevan University Health Board		S.1311	2009-06-01	
-2171	Ancient Monuments Board for Wales		S.1311		2003-06-01
-1017	Ancient Monuments Board for Scotland		S.1311		2006-04-01
-2167	Amlwch Port		S.1313		
-2164	Amercare Ltd - (s BNFL)		S.11001		
-2163	AMC Bank Ltd		S.12201		
-2162	Amble Development Trust Ltd		S.1313		
-1016	Amber Valley Borough Council		S.1313		
-1015	Allerdale Borough Council		S.1313		
-1014	Alcohol Education and Research Council		S.1311		2012-07-01
-2137	Airport Trading Ltd (s MA)		S.11001		2006-07-01
-2136	Airport Petroleum Ltd (s MA)		S.11001	2013-02-01	
-2135	Airport Management Services Limited (s H&IE)		S.1311		
-2134	Airport Management Consultants Ltd (s MA)		S.11001		2006-07-01
-2133	Airport Driving Range Company Limited		S.11001	2013-11-22	
-2132	Airport Advertising Ltd (s MA)		S.11001	2013-02-01	
-2131	Aire Valley Warehousing 3 Limited		S.12501		
-2130	Aire Valley Mortgages 2008-1 plc		S.12501		
-2129	Aire Valley Mortgages 2007-2 plc		S.12501		
-2128	Aire Valley Mortgages 2007-1 plc		S.12501		
-2127	Aire Valley Mortgages 2006-1 plc		S.12501		
-2126	Aire Valley Mortgages 2005-1 plc		S.12501		
-2125	Aire Valley Mortgages 2004-1 plc		S.12501		
-2124	Aire Valley Homes Leeds		S.11001		
-2123	Aire Valley Finance (No2) plc		S.12501		
-2122	Airborne Particles Expert Group		S.1311		
-2121	Air Travel Trust		S.1311	2008-04-01	
-2120	Air Safety Support International Ltd		S.1311	2000-11-01	
-1013	Agriculture and Horticulture Development Board		S.1311		
-2117	Agriculture and Environment Biotechnology Commission		S.1311		
-2116	Agricultural Wages Committees for Wales		S.1311		2007-03-01
-2115	Agricultural Wages Committees for England		S.1311		2013-12-01
-2114	Agricultural Wages Board for Northern Ireland		S.1311		
-2113	Agricultural Wages Board for England and Wales		S.1311		2013-06-01
-2112	Agricultural Research Institute of Northern Ireland		S.1311		2006-03-01
-2111	Agricultural Land Tribunals (England)		S.1311		2013-07-01
-2110	Agricultural Land Tribunal (Wales)		S.1311		
-2109	Agricultural Dwelling House Advisory Committees (Wales)		S.1311		2007-03-01
-1812	Agricultural Dwelling House Advisory Committees (England) (ADHAC)		S.1311		2013-12-01
-2108	Agricultural Development and Advisory Service		S.1311		
-2118	Agri-Food & Biosciences Institute		S.1311	2006-04-01	
-2107	Aggregator Vehicle PLC		S.1311	2014-08-08	
-2105	Age Concern Wiltshire		S.1313		
-2102	Aerospace Committee		S.1311		
-2100	AEA Technology		S.11001		
-2099	Advisory Panel on Standards for the Planning Inspectorate		S.1311		2010-06-01
-1012	Advisory Group on Military Medicine		S.1311	2008-08-01	
-2098	Advisory Group on Hepatitis		S.1311		
-1011	Advisory Council on the Misuse of Drugs		S.1311		
-2097	Advisory Council on Public Records		S.1311		2004-04-01
-1804	Advisory Council on National Records and Archives		S.1311	2004-04-01	
-2096	Advisory Council on Libraries		S.1311		
-1781	Advisory Conciliation and Arbitration Service		S.1311		
-2095	Advisory Committees on Justices of the Peace in Lancashire, Greater Manchester and Merseyside		S.1311		
-2094	Advisory Committees on Justices of the Peace in England and Wales		S.1311		
-1762	Advisory Committees on Justices of the Peace (Northern Ireland)		S.1311		2005-06-01
-2093	Advisory Committees on General Commissioners of Income Tax (Northern Ireland)		S.1311		2009-04-01
-2092	Advisory Committees on General Commissioners of Income Tax		S.1311		
-2091	Advisory Committee on Work-Life Balance		S.1311		
-1010	Advisory Committee on the Microbiological safety of Food		S.1311		
-2090	Advisory Committee on the Government Art Collection		S.1311		
-2089	Advisory Committee on Telecommunications for Disabled and Elderly People (DIEL)		S.1311		
-2088	Advisory Committee on Sites of Special Scientific Interest		S.1311		2011-04-01
-2087	Advisory Committee on Service Candidates		S.1311		
-1009	Advisory Committee on Releases to the Environment		S.1311		
-2086	Advisory Committee on Plant and Machinery		S.1311		
-1008	Advisory Committee on Pesticides		S.1311		2015-03-01
-2085	Advisory Committee on Packaging		S.1311		
-2084	Advisory Committee on Overseas Economic and Social Research		S.1311		2001-01-01
-1007	Advisory Committee on Novel Foods and Processes		S.1311		
-2083	Advisory Committee on National Health Service Drugs		S.1311		
-2082	Advisory Committee on Lifelong Learning Targets		S.1311		
-2081	Advisory Committee on Legal Education and Conduct		S.1311		
-2080	Advisory Committee on Juvenile Court Lay Panel (Northern Ireland)		S.1311		2005-04-01
-2079	Advisory Committee on Historic Wreck Sites		S.1311		2011-03-01
-2078	Advisory Committee on Hazardous Substances		S.1311		2012-07-01
-2077	Advisory Committee on Genetic Testing		S.1311		
-2076	Advisory Committee on Distinction Awards		S.1311		
-2075	Advisory Committee on Design Quality in the NHS		S.1311		
-2074	Advisory Committee on Dental Establishments		S.1311		
-2073	Advisory Committee on Dangerous Pathogens		S.1311		
-2072	Advisory Committee on Consumer Products and the Environment		S.1311		
-1006	Advisory Committee on Conscientious Objectors		S.1311		
-2071	Advisory Committee on Cleaner Coal Technology		S.1311		
-1005	Advisory Committee on Business Appointments		S.1311		
-2070	Advisory Committee on Business and the Environment		S.1311		
-2069	Advisory Committee on Breast Cancer Screening		S.1311		
-2068	Advisory Committee on Borderline Substances		S.1311		
-2067	Advisory Committee on Arbitration Law		S.1311		
-1004	Advisory Committee on Animal Feedingstuffs		S.1311		
-2066	Advisory Committee on Advertising		S.1311		2008-01-01
-2065	Advisory Committee of the Therapeutic Professions Allied to Medicine		S.1311		
-2064	Advisory Committee for Wales		S.1311		
-2063	Advisory Committee for the Joint Environmental Markets Unit		S.1311		
-2062	Advisory Committee for Disabled People in Employment and Training		S.1311		2002-04-01
-2061	Advisory Board on the Registration of Homeopathic Products		S.1311		
-2060	Advisory Board on Sustainable Development		S.1311		
-2059	Advisory Board on Restricted Patients		S.1311		
-2058	Advisory Board on Family Law		S.1311		2003-08-01
-2057	Advisory Board on Fair Trading in Telecommunications		S.1311		
-2056	Adventure Activities Licensing Authority/TQS Ltd		S.1311		
-1821	Advantage - West Midlands		S.1311		2012-07-01
-1003	Adur District Council		S.1313		
-1002	Adult Learning Inspectorate		S.1311		
-1001	Administration of Radioactive Substances Advisory Committee		S.1311		
-2051	Adam and Company plc		S.12201		
-2048	Actis		S.11001		
-2045	Accounts Commission for Scotland		S.1311		
-2044	Accountant General of the Supreme Court		S.1311		
-2043	Accountant General of the Senior Courts		S.1311		
-2033	Academy Trusts (En Bloc)		S.1311		
-2032	Academies (En Bloc)		S.1311	2002-07-01	
-2030	ABN Amro Bank NV		S.12201		
-2028	ABF The Soldiers Charity		S.1311		2013-03-01
-2026	Abertawe Bro Morgannwg University Health Board		S.1311	2009-06-01	
-1864	Aberdeenshire Council		S.1313		
-2024	Aberdeen Western Peripheral Route (AWPR) Special purpose Vehicles (SPVs)		S.1311	2014-12-11	
-2022	Aberdeen Harbour Board		S.11001		2015-12-02
-1863	Aberdeen City Council		S.1313		
-1897	A1 Housing Bassetlaw Ltd		S.11001	2008-07-22	
-1895	4 Ventures Ltd		S.11001	2000-11-01	
-1891	2010 Rotherham Ltd		S.11001		2011-07-01
-1889	124 Facilities Ltd - (s C4)		S.11001		2002-12-01
-1737		government-organisation:OT360	S.1311		2017-08-18
+1737	NA	government-organisation:OT360	S.1311	NA	2017-08-18
+1889	124 Facilities Ltd - (s C4)	NA	S.11001	NA	2002-12-01
+1891	2010 Rotherham Ltd	NA	S.11001	NA	2011-07-01
+1895	4 Ventures Ltd	NA	S.11001	2000-11-01	NA
+1897	A1 Housing Bassetlaw Ltd	NA	S.11001	2008-07-22	NA
+1863	NA	local-authority-sct:ABE	S.1313	NA	NA
+2022	Aberdeen Harbour Board	NA	S.11001	NA	2015-12-02
+2024	Aberdeen Western Peripheral Route (AWPR) Special purpose Vehicles (SPVs)	NA	S.1311	2014-12-11	NA
+1864	NA	local-authority-sct:ABD	S.1313	NA	NA
+2026	Abertawe Bro Morgannwg University Health Board	NA	S.1311	2009-06-01	NA
+2028	ABF The Soldiers Charity	NA	S.1311	NA	2013-03-01
+2030	ABN Amro Bank NV	NA	S.12201	NA	NA
+2032	Academies (En Bloc)	NA	S.1311	2002-07-01	NA
+2033	Academy Trusts (En Bloc)	NA	S.1311	NA	NA
+2043	Accountant General of the Senior Courts	NA	S.1311	NA	NA
+2044	Accountant General of the Supreme Court	NA	S.1311	NA	NA
+2045	Accounts Commission for Scotland	NA	S.1311	NA	NA
+2048	Actis	NA	S.11001	NA	NA
+2051	Adam and Company plc	NA	S.12201	NA	NA
+1001	Administration of Radioactive Substances Advisory Committee	NA	S.1311	NA	NA
+1002	NA	government-organisation:OT786	S.1311	NA	NA
+1003	NA	local-authority-eng:ADU	S.1313	NA	NA
+1821	NA	government-organisation:EA927	S.1311	NA	2012-07-01
+2056	Adventure Activities Licensing Authority/TQS Ltd	NA	S.1311	NA	NA
+2057	Advisory Board on Fair Trading in Telecommunications	NA	S.1311	NA	NA
+2058	Advisory Board on Family Law	NA	S.1311	NA	2003-08-01
+2059	Advisory Board on Restricted Patients	NA	S.1311	NA	NA
+2060	Advisory Board on Sustainable Development	NA	S.1311	NA	NA
+2061	Advisory Board on the Registration of Homeopathic Products	NA	S.1311	NA	NA
+2062	Advisory Committee for Disabled People in Employment and Training	NA	S.1311	NA	2002-04-01
+2063	Advisory Committee for the Joint Environmental Markets Unit	NA	S.1311	NA	NA
+2064	Advisory Committee for Wales	NA	S.1311	NA	NA
+2065	Advisory Committee of the Therapeutic Professions Allied to Medicine	NA	S.1311	NA	NA
+2066	Advisory Committee on Advertising	NA	S.1311	NA	2008-01-01
+1004	NA	government-organisation:PB573	S.1311	NA	NA
+2067	Advisory Committee on Arbitration Law	NA	S.1311	NA	NA
+2068	Advisory Committee on Borderline Substances	NA	S.1311	NA	NA
+2069	Advisory Committee on Breast Cancer Screening	NA	S.1311	NA	NA
+2070	Advisory Committee on Business and the Environment	NA	S.1311	NA	NA
+1005	NA	government-organisation:PB336	S.1311	NA	NA
+2071	Advisory Committee on Cleaner Coal Technology	NA	S.1311	NA	NA
+1006	NA	government-organisation:PB392	S.1311	NA	NA
+2072	Advisory Committee on Consumer Products and the Environment	NA	S.1311	NA	NA
+2073	Advisory Committee on Dangerous Pathogens	NA	S.1311	NA	NA
+2074	Advisory Committee on Dental Establishments	NA	S.1311	NA	NA
+2075	Advisory Committee on Design Quality in the NHS	NA	S.1311	NA	NA
+2076	Advisory Committee on Distinction Awards	NA	S.1311	NA	NA
+2077	Advisory Committee on Genetic Testing	NA	S.1311	NA	NA
+2078	Advisory Committee on Hazardous Substances	NA	S.1311	NA	2012-07-01
+2079	Advisory Committee on Historic Wreck Sites	NA	S.1311	NA	2011-03-01
+2080	Advisory Committee on Juvenile Court Lay Panel (Northern Ireland)	NA	S.1311	NA	2005-04-01
+2081	Advisory Committee on Legal Education and Conduct	NA	S.1311	NA	NA
+2082	Advisory Committee on Lifelong Learning Targets	NA	S.1311	NA	NA
+2083	Advisory Committee on National Health Service Drugs	NA	S.1311	NA	NA
+1007	NA	government-organisation:PB574	S.1311	NA	NA
+2084	Advisory Committee on Overseas Economic and Social Research	NA	S.1311	NA	2001-01-01
+2085	Advisory Committee on Packaging	NA	S.1311	NA	NA
+1008	NA	government-organisation:PB208	S.1311	NA	2015-03-01
+2086	Advisory Committee on Plant and Machinery	NA	S.1311	NA	NA
+1009	NA	government-organisation:PB209	S.1311	NA	NA
+2087	Advisory Committee on Service Candidates	NA	S.1311	NA	NA
+2088	Advisory Committee on Sites of Special Scientific Interest	NA	S.1311	NA	2011-04-01
+2089	Advisory Committee on Telecommunications for Disabled and Elderly People (DIEL)	NA	S.1311	NA	NA
+2090	Advisory Committee on the Government Art Collection	NA	S.1311	NA	NA
+1010	NA	government-organisation:PB575	S.1311	NA	NA
+2091	Advisory Committee on Work-Life Balance	NA	S.1311	NA	NA
+2092	Advisory Committees on General Commissioners of Income Tax	NA	S.1311	NA	NA
+2093	Advisory Committees on General Commissioners of Income Tax (Northern Ireland)	NA	S.1311	NA	2009-04-01
+1762	NA	government-organisation:PB437	S.1311	NA	2005-06-01
+2094	Advisory Committees on Justices of the Peace in England and Wales	NA	S.1311	NA	NA
+2095	Advisory Committees on Justices of the Peace in Lancashire, Greater Manchester and Merseyside	NA	S.1311	NA	NA
+1781	NA	government-organisation:PB28	S.1311	NA	NA
+2096	Advisory Council on Libraries	NA	S.1311	NA	NA
+1804	NA	government-organisation:PB438	S.1311	2004-04-01	NA
+2097	Advisory Council on Public Records	NA	S.1311	NA	2004-04-01
+1011	NA	government-organisation:PB271	S.1311	NA	NA
+2098	Advisory Group on Hepatitis	NA	S.1311	NA	NA
+1012	NA	government-organisation:PB393	S.1311	2008-08-01	NA
+2099	Advisory Panel on Standards for the Planning Inspectorate	NA	S.1311	NA	2010-06-01
+2100	AEA Technology	NA	S.11001	NA	NA
+2102	Aerospace Committee	NA	S.1311	NA	NA
+2105	Age Concern Wiltshire	NA	S.1313	NA	NA
+2107	Aggregator Vehicle PLC	NA	S.1311	2014-08-08	NA
+2118	Agri-Food & Biosciences Institute	NA	S.1311	2006-04-01	NA
+2108	Agricultural Development and Advisory Service	NA	S.1311	NA	NA
+1812	NA	government-organisation:PB421	S.1311	NA	2013-12-01
+2109	Agricultural Dwelling House Advisory Committees (Wales)	NA	S.1311	NA	2007-03-01
+2110	Agricultural Land Tribunal (Wales)	NA	S.1311	NA	NA
+2111	Agricultural Land Tribunals (England)	NA	S.1311	NA	2013-07-01
+2112	Agricultural Research Institute of Northern Ireland	NA	S.1311	NA	2006-03-01
+2113	Agricultural Wages Board for England and Wales	NA	S.1311	NA	2013-06-01
+2114	Agricultural Wages Board for Northern Ireland	NA	S.1311	NA	NA
+2115	Agricultural Wages Committees for England	NA	S.1311	NA	2013-12-01
+2116	Agricultural Wages Committees for Wales	NA	S.1311	NA	2007-03-01
+2117	Agriculture and Environment Biotechnology Commission	NA	S.1311	NA	NA
+1013	NA	government-organisation:OT204	S.1311	NA	NA
+2120	Air Safety Support International Ltd	NA	S.1311	2000-11-01	NA
+2121	Air Travel Trust	NA	S.1311	2008-04-01	NA
+2122	Airborne Particles Expert Group	NA	S.1311	NA	NA
+2123	Aire Valley Finance (No2) plc	NA	S.12501	NA	NA
+2124	Aire Valley Homes Leeds	NA	S.11001	NA	NA
+2125	Aire Valley Mortgages 2004-1 plc	NA	S.12501	NA	NA
+2126	Aire Valley Mortgages 2005-1 plc	NA	S.12501	NA	NA
+2127	Aire Valley Mortgages 2006-1 plc	NA	S.12501	NA	NA
+2128	Aire Valley Mortgages 2007-1 plc	NA	S.12501	NA	NA
+2129	Aire Valley Mortgages 2007-2 plc	NA	S.12501	NA	NA
+2130	Aire Valley Mortgages 2008-1 plc	NA	S.12501	NA	NA
+2131	Aire Valley Warehousing 3 Limited	NA	S.12501	NA	NA
+2132	Airport Advertising Ltd (s MA)	NA	S.11001	2013-02-01	NA
+2133	Airport Driving Range Company Limited	NA	S.11001	2013-11-22	NA
+2134	Airport Management Consultants Ltd (s MA)	NA	S.11001	NA	2006-07-01
+2135	Airport Management Services Limited (s H&IE)	NA	S.1311	NA	NA
+2136	Airport Petroleum Ltd (s MA)	NA	S.11001	2013-02-01	NA
+2137	Airport Trading Ltd (s MA)	NA	S.11001	NA	2006-07-01
+1014	NA	government-organisation:OT721	S.1311	NA	2012-07-01
+1015	NA	local-authority-eng:ALL	S.1313	NA	NA
+1016	NA	local-authority-eng:AMB	S.1313	NA	NA
+2162	Amble Development Trust Ltd	NA	S.1313	NA	NA
+2163	AMC Bank Ltd	NA	S.12201	NA	NA
+2164	Amercare Ltd - (s BNFL)	NA	S.11001	NA	NA
+2167	Amlwch Port	NA	S.1313	NA	NA
+1017	NA	government-organisation:OT988	S.1311	NA	2006-04-01
+2171	Ancient Monuments Board for Wales	NA	S.1311	NA	2003-06-01
+2174	Aneurin Bevan University Health Board	NA	S.1311	2009-06-01	NA
+2175	Angel Train Contracts	NA	S.11001	NA	NA
+2177	Anglian Water	NA	S.11001	NA	NA
+2178	Angus Council	NA	S.1313	NA	NA
+2180	Animal Diseases Research Association	NA	S.1311	NA	NA
+1018	NA	government-organisation:EA900	S.1311	NA	NA
+1816	NA	government-organisation:EA52	S.1311	NA	NA
+2181	Animal Planet (Latin Am) (50%) (sBBCW) (Associate)	NA	S.11001	NA	NA
+1019	NA	government-organisation:OT589	S.1311	NA	NA
+2182	Animal Welfare Advisory Committee (MOD)	NA	S.1311	NA	2010-07-01
+2183	Annan Harbour	NA	S.11001	NA	2015-12-02
+2185	Antrim and Newtownabbey Borough Council	NA	S.1313	NA	NA
+2186	Anvil Trust Ltd, The	NA	S.1313	NA	NA
+2189	Appeal Body (DVTA)	NA	S.1311	NA	NA
+2190	Appeals Service	NA	S.1311	NA	2006-04-01
+2191	Apple and Pear Research Council (APRC)	NA	S.1311	NA	NA
+1848	NA	government-organisation:OT801	S.1311	NA	2012-10-01
+2194	Arbroath Harbour	NA	S.1313	NA	NA
+1020	NA	government-organisation:PC163	S.11001	NA	NA
+2196	Architectural Heritage Fund	NA	S.1311	NA	NA
+2197	Architecture and Design Scotland	NA	S.1311	NA	NA
+2200	Ards and North Down Borough Council	NA	S.1313	NA	NA
+2201	Areas of Outstanding Natural Beauty (AONB) Conservation Boards (En Bloc)	NA	S.1313	NA	NA
+1849	NA	local-authority-sct:AGB	S.1313	NA	NA
+2205	Argyll Ferries Ltd	NA	S.1311	2011-02-01	NA
+2210	Armagh City, Banbridge and Craigavon Borough Council	NA	S.1313	NA	NA
+1021	NA	government-organisation:OT769	S.1311	NA	NA
+1797	NA	government-organisation:PB394	S.1311	NA	NA
+1022	NA	government-organisation:EA706	S.1311	NA	2007-04-01
+2211	Arms Length Management Organisations (ALMOs)	NA	S.11001	NA	NA
+1748	NA	government-organisation:EA816	S.11001	NA	NA
+2213	Army Base Storage and Distribution Agency	NA	S.1311	NA	NA
+2214	Army Personnel Centre	NA	S.1311	NA	2004-04-01
+2215	Army Technical Support Agency	NA	S.1311	NA	NA
+2216	Army Training and Recruiting Agency	NA	S.1311	NA	2006-04-01
+2220	Arts and Humanities Research Board	NA	S.1311	NA	2005-04-01
+1720	NA	government-organisation:PB123	S.1311	2005-04-01	NA
+2221	Arts Council for Wales National Lottery	NA	S.1311	NA	NA
+1842	NA	government-organisation:PB165	S.1311	NA	NA
+1023	NA	government-organisation:EA740	S.1311	NA	NA
+1024	NA	government-organisation:OT731	S.1311	NA	NA
+1025	NA	local-authority-eng:ARU	S.1313	NA	NA
+2223	Ascension Island Personnel Ltd (50%) (sWS) (Associate)	NA	S.11001	NA	2004-04-01
+2225	Ascham Homes Ltd	NA	S.11001	NA	NA
+1026	NA	local-authority-eng:ASH	S.1313	NA	NA
+2228	Ashfield Homes Ltd	NA	S.11001	NA	NA
+1027	NA	local-authority-eng:ASF	S.1313	NA	NA
+2235	Ashworth Hospital Authority	NA	S.1311	NA	NA
+1028	NA	government-organisation:EA949	S.1311	NA	2012-10-01
+1029	NA	government-organisation:EA698	S.1311	NA	2008-04-01
+2239	Association of London Government	NA	S.1313	NA	NA
+2240	Association of Port Health Authorities	NA	S.1313	NA	NA
+2241	Association of Town Centre Management	NA	S.1313	NA	NA
+1030	NA	government-organisation:D1	S.1311	NA	NA
+2249	Auchmithie Harbour	NA	S.11001	NA	2015-12-02
+1031	NA	government-organisation:PC343	S.11001	NA	2015-03-31
+2251	Audit Commission Pension Scheme (The)	NA	S.12901	2012-05-31	NA
+2252	Audit Scotland	NA	S.11001	NA	NA
+2254	Averon Leisure Management Limited	NA	S.1313	NA	2014-04-01
+2255	Aviation Committee	NA	S.1311	NA	NA
+2256	Avoch Harbour	NA	S.11001	NA	2015-12-02
+2257	AWE [Atomic Weapons Establishment] Management Ltd	NA	S.11001	NA	NA
+2258	AWE [Atomic Weapons Establishment] Plc	NA	S.11001	NA	NA
+2260	Aycliffe - (s NTC)	NA	S.1311	NA	NA
+1032	NA	local-authority-eng:AYL	S.1313	NA	NA
+2261	Aylesham and District Community Workshop Trust	NA	S.1313	NA	NA
+1033	NA	local-authority-eng:BAB	S.1313	NA	NA
+2266	Baileyfield Switch and Crossing Works	NA	S.11001	NA	NA
+2267	Bainsdown Ltd (s MA)	NA	S.11001/03	2013-02-01	NA
+1034	NA	government-organisation:OT1016	S.121	NA	NA
+2275	Bank of Scotland plc	NA	S.12201	NA	2014-03-01
+2276	Banking Department	NA	S.121	NA	NA
+2277	Barbican Centre	NA	S.1313	NA	NA
+2279	Barnet Homes Ltd	NA	S.11001	NA	NA
+1035	NA	local-authority-eng:BNS	S.1313	NA	NA
+2282	Barnstaple Port	NA	S.1313	NA	NA
+1036	NA	local-authority-eng:BAR	S.1313	NA	NA
+2287	Basic Skills Agency	NA	S.1311	NA	2009-05-01
+2288	Basildon - (s NTC)	NA	S.1311	NA	NA
+1037	NA	local-authority-eng:BAI	S.1313	NA	NA
+1038	NA	local-authority-eng:BAN	S.1313	NA	NA
+2289	Basingstoke Dial-a-Ride	NA	S.1313	NA	NA
+1039	NA	local-authority-eng:BAE	S.1313	NA	NA
+1040	NA	local-authority-eng:BAS	S.1313	NA	NA
+2292	BBC Commercial Holdings Limited	NA	S.1311	2002-06-18	NA
+2293	BBC do Brazil Limitada (Brazil) (sWS)	NA	S.11001	NA	NA
+2294	BBC East Asia Relay Company Ltd [Hong Kong] (s WS)	NA	S.11001	NA	NA
+2295	BBC Haymarket Exhibitions Ltd (50%) (sBBCW) (Associate)	NA	S.11001	NA	2014-05-23
+2296	BBC Magazines Inc. [USA] (s BBCW)	NA	S.11001	NA	NA
+2297	BBC Pension Scheme	NA	S.12901	1949-06-01	NA
+2298	BBC Polska SP Zoo [Poland] (s WS)	NA	S.11001	NA	NA
+2299	BBC Radiocom (Bulgaria) OLLC [Bulgaria] (s WS)	NA	S.11001	NA	NA
+2300	BBC Radiocom (Hungary) Ltd [Hungary] (s WS)	NA	S.11001	NA	NA
+2301	BBC Radiocom (Praha) Sro [Czech Republic] (s WS)	NA	S.11001	NA	NA
+2302	BBC Radiocom (Romania) SRL [Romania] (s WS)	NA	S.11001	NA	NA
+2303	BBC Radiocom (Slovakia) Ltd [Slovakia] (s WS)	NA	S.11001	NA	NA
+2304	BBC Radiocom Deutschland GmbH (Germany) (sWS)	NA	S.11001	NA	NA
+1763	NA	government-organisation:PC427	S.1311	NA	NA
+2305	BBC World Service Television Ltd (s BBCW)	NA	S.11001	NA	NA
+2306	BBC World Service Training Trust (s WS)	NA	S.11001	NA	NA
+2307	BBC Worldwide (France) SARL [France] (s BBCW)	NA	S.11001	NA	NA
+2308	BBC Worldwide (Germany) GMBH [Germany] (s BBCW)	NA	S.11001	NA	NA
+2309	BBC Worldwide (Investments) Ltd (s BBCW)	NA	S.11001	NA	NA
+2310	BBC Worldwide Americas Inc.[USA] (s BBCW)	NA	S.11001	NA	NA
+2311	BBC Worldwide Channel Investment Ltd (s BBCW)	NA	S.11001	NA	NA
+2312	BBC Worldwide Ltd (BBCW)- (s HS)	NA	S.11001	NA	NA
+2313	BBC Worldwide Music Ltd (s BBCW)	NA	S.11001	NA	NA
+2314	BCE Corporate Functions Ltd	NA	S.11001	NA	NA
+2315	Beacon Waste Ltd	NA	S.1313	NA	NA
+2316	Beaumaris Port	NA	S.1313	NA	NA
+1041	NA	local-authority-eng:BDF	S.1313	NA	NA
+2320	Bedfordshire, Cambridgeshire, Hertfordshire and Northamptonshire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+2322	Beeches Road Community Enterprise Ltd	NA	S.1313	NA	NA
+2323	Beef Assurance Scheme Membership Panel	NA	S.1311	NA	2005-12-01
+2325	Belfast Airport	NA	S.11001	NA	NA
+2326	Belfast City Council	NA	S.1313	NA	NA
+2327	Belfast Education and Library Board	NA	S.1311	NA	NA
+2328	Belfast Harbour Commissioners	NA	S.11001	NA	NA
+2329	Belfast Health and Social Care Trust	NA	S.1311	2010-04-01	NA
+2330	Belgrade Theatre	NA	S.1313	NA	NA
+2334	Benefits Agency	NA	S.1311	NA	2002-04-01
+2337	Berkshire Young Musicians Trust	NA	S.1313	NA	NA
+2338	Berneslai Homes Ltd	NA	S.11001	NA	NA
+2346	Betsi Cadwaladr University Health Board	NA	S.1311	2009-06-01	NA
+2347	Better Regulation Task Force	NA	S.1311	NA	NA
+2351	Bideford Port	NA	S.1313	NA	NA
+1042	NA	government-organisation:PB188	S.1311	NA	NA
+2353	Big Society Capital	NA	S.1311	NA	2016-01-01
+2354	Big Society Foundation	NA	S.1311	NA	2016-01-01
+2355	Big Society Trust	NA	S.1311	NA	2016-01-01
+2356	Biggin Hill Aerodrome	NA	S.1313	NA	NA
+2357	BIL Solutions Ltd - (s BNG / BNFL)	NA	S.11001	NA	NA
+2359	Bio Products Laboratory Ltd	NA	S.11001	NA	2013-07-01
+1713	NA	government-organisation:PB317	S.1311	NA	NA
+2363	Birmingham Airport	NA	S.11001	NA	NA
+2364	Birmingham BRIS	NA	S.11001	NA	NA
+1043	NA	local-authority-eng:BIR	S.1313	NA	NA
+2367	Birmingham Heartlands UDC	NA	S.11001	NA	NA
+2371	BIS (Postal Services Act 2011) B Company Limited	NA	S.1311	2012-02-01	NA
+2372	BIS (Postal Services Act 2011) Company Limited	NA	S.1311	2012-02-01	NA
+1044	NA	local-authority-eng:BLA	S.1313	NA	NA
+2373	Black Country Development Corporation	NA	S.11001	NA	NA
+2375	Black Horse Ltd	NA	S.12201	NA	2014-03-01
+2376	Blackburn Borough Transport	NA	S.11001	NA	NA
+1045	NA	local-authority-eng:BBD	S.1313	NA	NA
+2378	Blackpool Airport Ltd	NA	S.11001	NA	NA
+2379	Blackpool Challenge Partnership Ltd	NA	S.1313	NA	NA
+2380	Blackpool Coastal Housing Ltd	NA	S.11001	NA	NA
+2381	Blackpool Council	NA	S.1313	NA	NA
+2383	Blackpool Fylde and Wyre Society for the Blind, The	NA	S.1313	NA	NA
+2384	Blackpool Grand Theatre (Arts and Entertainment) Ltd	NA	S.1313	NA	NA
+2385	Blackpool Grand Theatre Catering Ltd	NA	S.1313	NA	NA
+2386	Blackpool Grand Theatre Trust Ltd	NA	S.1313	NA	NA
+2387	Blackpool Operating Company Ltd	NA	S.1313	NA	NA
+2388	Blackpool Town Centre Forum Ltd	NA	S.1313	NA	NA
+2389	Blackpool Transport Services Ltd	NA	S.11001	NA	NA
+1046	NA	principal-local-authority:BGW	S.1313	NA	NA
+2399	Blyth Harbour Commissioners	NA	S.11001	NA	NA
+2400	Blyth Valley Housing Ltd	NA	S.11001	NA	NA
+2401	BNFL (IP) Ltd (s. BNFL)	NA	S.11001	NA	NA
+2402	BNFL Engineering Ltd - (s BNFL)	NA	S.11001	NA	NA
+2403	BNFL Enrichment Ltd - (BNFL)	NA	S.11001	NA	2009-12-01
+2404	BNFL Enterprise - (s BNG / BNFL)	NA	S.11001	NA	NA
+2405	BNFL Interim Storage Ltd - (s BNFL)	NA	S.11001	NA	NA
+2406	BNFL Properties Limited - (s BNG / BNFL)	NA	S.11001	NA	NA
+2407	Boards of Visitors and Visiting Committees (Northern Ireland)	NA	S.1311	NA	NA
+2408	Boards of Visitors to Penal Establishments	NA	S.1311	NA	NA
+2410	Bognor Regis Ltd	NA	S.1313	NA	NA
+1047	NA	local-authority-eng:BOS	S.1313	NA	NA
+2413	Bolton at Home Ltd	NA	S.11001	NA	2011-03-01
+2414	Bolton Council	NA	S.1313	NA	NA
+2418	Booth & Fisher (Motor Services) Ltd - (s SYPTE)	NA	S.11001	NA	1905-06-17
+2419	Bòrd na Gàidhlig	NA	S.1311	NA	NA
+2421	Borough of Broxbourne	NA	S.1313	NA	NA
+1048	NA	local-authority-eng:POL	S.1313	NA	NA
+1049	NA	local-authority-eng:BOT	S.1313	NA	NA
+2424	Boston Port	NA	S.1313	NA	NA
+2425	Botanics Trading Company Ltd	NA	S.11001	NA	NA
+1050	NA	government-organisation:OT428	S.1311	NA	NA
+1051	NA	government-organisation:OT431	S.1311	NA	NA
+1885	NA	government-organisation:PB337	S.1311	NA	NA
+2428	Bournemouth Airport Property Investments (Industrial) Ltd	NA	S.11001/3	2013-02-01	NA
+2429	Bournemouth Airport Property Investments (Offices) Ltd	NA	S.11001/3	2013-02-01	NA
+1052	NA	local-authority-eng:BMH	S.1313	NA	NA
+2431	Bournemouth International Airport Ltd (s MA)	NA	S.11001/3	2013-02-01	NA
+2432	Bournemouth Transport Ltd	NA	S.11001	NA	NA
+2437	BPE Mechanical and Electrical Engineering Consultancy	NA	S.11001	NA	NA
+2438	BPEX Ltd	NA	S.1311	NA	NA
+2440	BPL Holdings Ltd (Formerly Plasma Resources UK Ltd)	NA	S.11001	NA	2013-07-01
+2441	BR Property Board (s BRB)	NA	S.11001	NA	NA
+2442	Bracknell - (s NTC)	NA	S.1311	NA	NA
+2443	Bracknell Forest Borough Council	NA	S.1313	NA	NA
+2445	Bradford & Bingley Pension Scheme	NA	S.12901	2008-09-29	NA
+2446	Bradford & Bingley plc	NA	S.1311	2010-07-01	NA
+2447	Bradford Film Limited	NA	S.1311	2010-04-01	NA
+1852	NA	local-authority-eng:BRD	S.1313	NA	NA
+1053	NA	local-authority-eng:BRA	S.1313	NA	NA
+1725	NA	government-organisation:PC467	S.1311	NA	NA
+2452	Breckland Council	NA	S.1313	NA	NA
+2453	Brecon Beacons National Park Authority	NA	S.1313	1995-11-01	NA
+1054	NA	local-authority-eng:BRW	S.1313	NA	NA
+1055	NA	principal-local-authority:BGE	S.1313	NA	NA
+2462	Bridlington Pier and Harbour Commissioners	NA	S.11001	NA	NA
+2463	Bridport Port	NA	S.1313	NA	NA
+1056	NA	local-authority-eng:BNH	S.1313	NA	NA
+2468	Brighton Buses Ltd	NA	S.11001	NA	NA
+2472	Bristol Airport	NA	S.11001	NA	NA
+1057	NA	local-authority-eng:BST	S.1313	NA	NA
+2476	Bristol Development Corporation	NA	S.11001	NA	NA
+2477	Bristol Port	NA	S.1313	NA	NA
+2478	Bristol, Gloucestershire, Somerset & Wiltshire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+2480	British Airports Authority	NA	S.11001	NA	NA
+2481	British Airways	NA	S.11001	NA	NA
+2482	British Antarctic Survey	NA	S.1311	NA	NA
+2483	British Association for Central & Eastern Europe	NA	S.1311	NA	NA
+2484	British Board of Agrement	NA	S.1311	NA	NA
+2485	British Broadcasting Corporation - (BBC)	NA	S.1311	NA	NA
+1749	NA	government-organisation:OT1148	S.1311	2013-07-01	NA
+2486	British Coal (Mines)	NA	S.11001	NA	NA
+2487	British Coal Corporation	NA	S.11001	NA	NA
+2488	British Coal Staff Superannuation Scheme	NA	S.12901	1994-10-31	NA
+1058	NA	government-organisation:OT313	S.11001	NA	NA
+1717	NA	government-organisation:EA932	S.1311	NA	2011-03-01
+2489	British Electricity Authority	NA	S.11001	NA	NA
+2490	British Energy	NA	S.11001	NA	NA
+2491	British European Airways	NA	S.11001	NA	NA
+2492	British Film Commission	NA	S.1311	NA	NA
+1059	NA	government-organisation:PB189	S.1311	NA	NA
+1060	NA	government-organisation:OT878	S.1311	NA	2007-04-01
+2493	British Fuels	NA	S.11001	NA	NA
+2494	British Fuels (Ireland) Ltd	NA	S.11001	NA	2007-12-01
+2495	British Fuels Distributors Ltd	NA	S.11001	NA	2002-01-01
+2496	British Gas	NA	S.11001	NA	NA
+2497	British Geological Survey	NA	S.1311	NA	NA
+2498	British Government Panel on Sustainable Development	NA	S.1311	NA	NA
+1061	NA	government-organisation:PB124	S.1311	1905-05-27	NA
+1062	NA	government-organisation:PB166	S.1311	NA	NA
+1063	NA	government-organisation:PB167	S.1311	NA	NA
+2499	British Museum Company Ltd	NA	S.11001	NA	NA
+2500	British National Oil Company	NA	S.11001	NA	NA
+2501	British Nuclear Fuels plc (BNFL)	NA	S.11001	NA	NA
+2502	British Nuclear Group Ltd. (s. BNFL)	NA	S.11001	NA	NA
+2503	British Nuclear Group Project Services Ltd. (s. BNG / BNFL)	NA	S.11001	NA	NA
+2504	British Nuclear Group Sellafield Ltd. (s. BNG / BNFL)	NA	S.11001	NA	NA
+2505	British Nuclear Services Ltd. (s. BNG / BNFL)	NA	S.11001	NA	NA
+2506	British Overseas Trade Board	NA	S.1311	NA	NA
+1064	NA	government-organisation:PB524	S.1311	NA	NA
+1065	NA	government-organisation:OT887	S.1311	NA	NA
+2507	British Railways Board - (BRB)	NA	S.11001	NA	NA
+2508	British Screen Finance Limited	NA	S.12401	1985-05-02	NA
+2509	British Shipbuilders	NA	S.1311	NA	2012-03-01
+2510	British Tourist Authority	NA	S.1311	NA	NA
+2511	British Transport Police (sSRA)	NA	S.1311	NA	NA
+1066	NA	government-organisation:PB461	S.1311	NA	NA
+2512	British Waterways Board - (BWB)	NA	S.11001	NA	NA
+2513	British Waterways Pension Trustees Ltd - (s BWB)	NA	S.11001	NA	NA
+2514	British Wool Marketing Board	NA	S.11001	1905-05-11	NA
+2515	Brixham Port	NA	S.1313	NA	NA
+2519	Broadcasters Audience Research Board Ltd (50%) (sBBCW) (Associate)	NA	S.11001	NA	NA
+2520	Broadcasting Complaints Commission	NA	S.1311	NA	NA
+2521	Broadcasting Data services Ltd	NA	S.11001	NA	NA
+1067	NA	government-organisation:OT1001	S.1311	NA	NA
+1068	NA	local-authority-eng:BRO	S.1313	NA	NA
+2524	Broadmoor Special Hospital Authority	NA	S.1311	NA	NA
+1069	NA	government-organisation:OT216	S.1311	1988-06-01	NA
+1070	NA	local-authority-eng:BRM	S.1313	NA	NA
+2534	Brownies Taing (Lerwick)	NA	S.11001	NA	2015-12-02
+1071	NA	local-authority-eng:BRT	S.1313	NA	NA
+2539	Buckie Port	NA	S.1313	NA	NA
+1072	NA	local-authority-eng:BKM	S.1313	NA	NA
+2542	Bude Port	NA	S.1313	NA	NA
+1073	NA	government-organisation:PB160	S.1311	NA	NA
+2544	Building Societies Commission	NA	S.1311	NA	NA
+2545	Building Standards Advisory Committee	NA	S.1311	NA	2010-07-01
+2546	Burghead Port	NA	S.1313	NA	NA
+1074	NA	local-authority-eng:BUN	S.1313	NA	NA
+2547	Burnmouth Harbour	NA	S.11001	NA	2015-12-02
+2548	Burry Port	NA	S.1313	NA	NA
+1075	NA	local-authority-eng:BUR	S.1313	NA	NA
+2549	Business Advisory Committee on Telecommunications	NA	S.1311	NA	NA
+2550	Business and Technology Education Council	NA	S.1311	NA	NA
+2555	Buying Agency, The	NA	S.11001	NA	NA
+1076	NA	government-organisation:OT911	S.1311	NA	NA
+1077	NA	government-organisation:D2	S.1311	NA	NA
+2560	CADCAM Applications Training and Support Limited	NA	S.1313	NA	NA
+2562	Cadw (Welsh Historic Monuments)	NA	S.1311	NA	NA
+2564	Caernarvon Harbour Trustees	NA	S.11001	NA	NA
+1078	NA	principal-local-authority:CAY	S.1313	NA	NA
+2566	Cairngorms National Park Authority	NA	S.1313	2003-03-01	NA
+1079	NA	local-authority-eng:CLD	S.1313	NA	NA
+2569	Caledonian MacBrayne (HR) UK Ltd	NA	S.11001	NA	2007-11-01
+2570	Caledonian MacBrayne Ltd	NA	S.11001	NA	2006-10-01
+2571	Caledonian Maritime Assets Ltd	NA	S.11001	NA	NA
+2573	CalMac Ferries Ltd	NA	S.11001	NA	NA
+1080	NA	local-authority-eng:CAB	S.1313	NA	NA
+1081	NA	local-authority-eng:CAM	S.1313	NA	NA
+2579	Camden ITEC	NA	S.1313	NA	NA
+2581	Camden Mediation Service	NA	S.1313	NA	NA
+2582	Campbeltown Port	NA	S.1313	NA	NA
+2584	Canal & River Trust	NA	S.11001	2012-07-02	NA
+1082	NA	local-authority-eng:CAN	S.1313	NA	NA
+1083	NA	local-authority-eng:CAT	S.1313	NA	NA
+1084	NA	government-organisation:PB147	S.1311	NA	2013-10-01
+2586	Cardiff and Vale University Health Board	NA	S.1311	2009-06-01	NA
+2587	Cardiff Bay Development Corporation	NA	S.11001	NA	NA
+2588	Cardiff City Transport Services Ltd	NA	S.11001	NA	NA
+2590	Cardiff Council	NA	S.1313	NA	NA
+2591	Cardiff International Airport Ltd	NA	S.11001	2013-03-01	NA
+2594	Care Council for Wales	NA	S.1311	NA	NA
+1085	NA	government-organisation:PB251	S.1311	NA	NA
+2596	Careers Scotland	NA	S.1311	NA	2008-04-01
+2597	Careers Wales Association Ltd	NA	S.1311	2013-04-01	NA
+2598	Careers Wales Cardiff and Vale Ltd	NA	S.1311	2013-04-01	NA
+2599	Careers Wales Dewis Gyrfa Ltd	NA	S.1311	2013-04-01	NA
+2600	Careers Wales Mid Glamorgan and Powys Ltd	NA	S.1311	2013-04-01	NA
+3948	Careers Wales West - Gyrda Cymru Gorllewin Ltd	NA	S.1311	2013-04-01	NA
+3950	Carlisle (Crosby) Aerodrome	NA	S.1313	NA	NA
+1086	NA	local-authority-eng:CAR	S.1313	NA	NA
+3951	Carmarthen Port	NA	S.1313	NA	NA
+1087	NA	principal-local-authority:CMN	S.1313	NA	NA
+3952	Carrick Housing Ltd	NA	S.11001	NA	2010-04-01
+3953	Cart River Port (Paisley)	NA	S.1313	NA	NA
+1088	NA	local-authority-eng:CAS	S.1313	NA	NA
+3963	Causeway Coast and Glens District Council	NA	S.1313	NA	NA
+3965	CCTA- The Government Centre for Information Systems	NA	S.1311	NA	NA
+3967	CEEP UK	NA	S.1311	NA	NA
+3968	Cellardyke Port	NA	S.1313	NA	NA
+3969	Central Adjudication Services	NA	S.1311	NA	NA
+1868	Central Advisory Committee on Justices of the Peace (Scotland)	NA	S.1311	NA	NA
+1089	NA	government-organisation:PB395	S.1311	NA	NA
+1090	NA	government-organisation:PB148	S.1311	NA	NA
+1091	NA	local-authority-eng:CBF	S.1313	NA	NA
+3971	Central Council for Education and Training in Social Work (UK)	NA	S.1311	NA	NA
+3972	Central Electricity Generating Board	NA	S.1311	NA	NA
+3973	Central Fire Brigades Advisory Council	NA	S.1311	NA	NA
+3974	Central Laboratory of the Research Councils	NA	S.1311	NA	2007-04-01
+3975	Central Lancashire - (s NTC)	NA	S.1311	NA	NA
+3976	Central Manchester Development Corporation	NA	S.11001	NA	NA
+1092	NA	government-organisation:OT846	S.11001	NA	2012-05-01
+1093	NA	government-organisation:OT819	S.1311	NA	NA
+3977	Central Rail Users Consultative Committee (CRUCC)	NA	S.1311	NA	NA
+1094	NA	government-organisation:EA821	S.1311	NA	2009-04-01
+3978	Central Scotland Fire Board	NA	S.1313	NA	1905-06-27
+3979	Centre for Ecology and Hydrology	NA	S.1311	NA	NA
+3980	Centre for Environment Fisheries and Aquaculture Science Technology Ltd	NA	S.11001	NA	NA
+1716	NA	government-organisation:EA53	S.1311	1905-06-19	NA
+3981	Centre for Management and Policy Studies	NA	S.1311	NA	NA
+3982	Centre House Productions Ltd (CHP) - (s BBC)	NA	S.11001	NA	NA
+1095	NA	principal-local-authority:CGN	S.1313	NA	NA
+3986	Chamberlain of London	NA	S.1313	NA	NA
+3987	Chancellor of the Duchy of Lancaster	NA	S.1311	NA	NA
+3989	Channel Four International Ltd - (s C4)	NA	S.11001	NA	2007-11-01
+3990	Channel Four Learning Ltd - (s C4)	NA	S.11001	NA	2000-06-01
+1820	NA	government-organisation:PC386	S.11001	NA	1992-12-01
+3991	Channel Four Television Corporation Ltd (C4)	NA	S.11001	NA	NA
+3992	Channel Tunnel Rail Link Limited	NA	S.11001	NA	NA
+3995	Charities Advisory Committee	NA	S.1311	NA	NA
+3997	Charity Commission for England and Wales	NA	S.1311	NA	NA
+3998	Charity Commission of Northern Ireland	NA	S.1311	2009-06-01	NA
+1096	NA	local-authority-eng:CHA	S.1313	NA	NA
+4017	Charnwood Neighbourhood Housing Ltd	NA	S.11001	NA	2012-11-01
+1097	NA	local-authority-eng:CHL	S.1313	NA	NA
+1098	NA	local-authority-eng:CHT	S.1313	NA	NA
+4023	Cheltenham Borough Homes Ltd	NA	S.11001	NA	NA
+4025	Chepstow Port	NA	S.1313	NA	NA
+4026	Chequers Trust	NA	S.1311	NA	NA
+1099	NA	local-authority-eng:CHR	S.1313	NA	NA
+4032	Cheshire & Greater Manchester Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1100	NA	local-authority-eng:CHE	S.1313	NA	NA
+1101	NA	local-authority-eng:CHW	S.1313	NA	NA
+4034	Chester City Transport Ltd	NA	S.11001	NA	NA
+1102	NA	local-authority-eng:CHS	S.1313	NA	NA
+4036	Chevening Estate/Trust	NA	S.1311	NA	NA
+1103	NA	local-authority-eng:CHI	S.1313	NA	NA
+4039	Chichester Harbour Conservancy Board	NA	S.11001	NA	NA
+4040	Chief Electoral Officer for Northern Ireland	NA	S.1311	NA	NA
+4041	Chief Executive of Skills Funding	NA	S.1311	NA	NA
+4042	Child Care Law Review Body	NA	S.1311	NA	NA
+1724	NA	government-organisation:OT926	S.1311	NA	2012-08-01
+4043	Child Support Agency	NA	S.1311	NA	2008-11-01
+4044	Child Support Appeal Tribunals	NA	S.1311	NA	NA
+1831	NA	government-organisation:PB246	S.1311	NA	NA
+4046	Children's Panels Advisory Committee (reclassified from CG in 98q3)	NA	S.1313	NA	NA
+4047	Children's Trust Boards (En Bloc)	NA	S.1313	NA	NA
+1104	NA	government-organisation:OT915	S.1311	NA	2012-06-01
+4045	Children’s Commissioner for Wales	NA	S.1311	NA	NA
+1105	NA	local-authority-eng:CHN	S.1313	NA	NA
+4055	Chorley Council	NA	S.1313	NA	NA
+1106	NA	local-authority-eng:CHC	S.1313	NA	NA
+4061	Churches Conservation Trust	NA	S.1311	NA	NA
+4067	City Academies (En Bloc)	NA	S.1311	NA	NA
+4068	City Airport Rail Enterprises (Holdings) Limited	NA	S.1313	2011-11-01	NA
+4069	City Airport Rail Enterprises Plc	NA	S.1313	2011-11-01	NA
+1759	NA	principal-local-authority:SWA	S.1313	NA	NA
+4070	City Colleges for the Technology of the Arts (En Bloc)	NA	S.1311	1988-07-01	NA
+4071	City of Dundee District Council Launderette	NA	S.1313	NA	NA
+4072	City of Edinburgh District Council Market	NA	S.1313	NA	NA
+4074	City of Glasgow District Council Market	NA	S.1313	NA	NA
+1107	NA	local-authority-eng:LIC	S.1313	NA	NA
+1108	NA	local-authority-eng:LND	S.1313	NA	NA
+4077	City of London Police	NA	S.1313	NA	NA
+1109	NA	local-authority-eng:YOR	S.1313	NA	NA
+4080	City Technology Colleges (En Bloc)	NA	S.1311	2010-05-01	NA
+4083	Citybus Ltd - (s NITHC)	NA	S.11001	NA	NA
+4084	CityWest Homes Ltd	NA	S.11001	NA	NA
+1752	NA	government-organisation:PC469	S.11001	NA	NA
+4085	Civil Aviation Authority International Ltd (CAA International Ltd)	NA	S.11001	2000-11-01	NA
+1110	NA	government-organisation:PB293	S.1311	NA	NA
+1776	Civil Nuclear Police Authority	NA	S.1311	2005-04-01	NA
+1111	NA	government-organisation:PB440	S.1311	NA	NA
+4086	Civil Service Annuities Assurance Society, The	NA	S.12801	NA	2003-05-01
+4087	Civil Service Appeal Board	NA	S.1311	NA	NA
+4088	Civil Service Arbitration Tribunal	NA	S.1311	NA	NA
+1112	NA	government-organisation:PB366	S.1311	2010-11-01	NA
+4089	Civil Service Occupational Health and Safety Agency	NA	S.1311	NA	NA
+1843	NA	local-authority-sct:CLK	S.1313	NA	NA
+4094	CLIK (Central Laboratory Innovation and Knowledge Transfer Co.Ltd)	NA	S.11001	NA	NA
+4095	Clinical Commissioning Groups (En Bloc)	NA	S.1311	2013-04-01	NA
+4096	Clinical Engineering and Medical Physics Services Advisory Committee	NA	S.1311	NA	NA
+4097	Clinical Imaging Services Advisory Committee	NA	S.1311	NA	NA
+4098	Clinical Standards Advisory Group	NA	S.1311	NA	NA
+4099	Clinical Standards Board for Scotland (The)	NA	S.1311	NA	2003-01-01
+4102	Clothing and Allied Products Industry Training Board	NA	S.1311	NA	NA
+4103	Clothing and Industry Training Boards (NI)	NA	S.1311	NA	NA
+4107	Clydebank Municipal Bank Ltd	NA	S.12501	NA	NA
+4109	CNC Building Control Consultancy Joint Committee	NA	S.11001	NA	NA
+1113	NA	government-organisation:PB195	S.1311	NA	NA
+4110	Coal Developments (Queensland) Ltd - (s BCC)	NA	S.11001	NA	NA
+4111	Coal Industry Estates Ltd - (s BCC)	NA	S.11001	NA	NA
+4112	Coal Industry Patents Ltd - (s BCC)	NA	S.11001	NA	NA
+4115	Coastguard	NA	S.1311	NA	NA
+1114	NA	local-authority-eng:COL	S.1313	NA	NA
+4119	Colchester Borough Homes Ltd	NA	S.11001	NA	NA
+4120	Colchester Port	NA	S.1313	NA	NA
+4121	Coleraine District Policing Partnership	NA	S.1313	NA	NA
+4122	Coleraine Harbour Commissioners	NA	S.11001	NA	NA
+4123	Coll Aerodrome	NA	S.1313	NA	NA
+4124	College of Arms	NA	S.1311	NA	NA
+4125	College of Policing	NA	S.1311	2013-02-01	NA
+4126	Colleges of Further Education (Scotland) (En Bloc)	NA	S.1311	1993-04-01	NA
+4127	Collieston Harbour	NA	S.11001	NA	2015-12-02
+4132	Combined Courts (En Bloc)	NA	S.1311	NA	NA
+1836	NA	local-authority-sct:ELS	S.1313	NA	NA
+1715	NA	government-organisation:PB842	S.1311	NA	2011-04-01
+1115	NA	government-organisation:OT683	S.1311	NA	NA
+4133	Commission for Integrated Transport	NA	S.1311	NA	NA
+4134	Commission for Judicial Appointments (Scotland)	NA	S.1311	NA	NA
+4135	Commission for Local Administration	NA	S.1311	NA	NA
+4136	Commission for Local Administration in Wales	NA	S.1311	NA	NA
+4137	Commission for New Towns	NA	S.1311	NA	NA
+1116	NA	government-organisation:OT822	S.1311	NA	2008-06-01
+1117	NA	government-organisation:OT890	S.1311	NA	NA
+1768	NA	government-organisation:OT824	S.1311	NA	2009-03-01
+4138	Commission for the New Economy Ltd	NA	S.1313	NA	NA
+4139	Commission for Victims and Survivors	NA	S.1311	2008-05-01	NA
+4140	Commissioner for Ethical Standards in Public Life in Scotland	NA	S.1311	2011-04-01	NA
+1851	NA	government-organisation:OT941	S.1311	NA	NA
+1881	NA	government-organisation:OT940	S.1311	NA	NA
+4141	Commissioner of the Metropolis (Metropolitan Police Force)	NA	S.1313	2012-01-01	NA
+4142	Commissioners of Irish Lights, The	NA	S.1311	1905-04-29	NA
+4143	Commissioners of Taxes for the City of London	NA	S.1313	NA	NA
+4144	Committee for Monitoring Agreements On Tobacco Advertising Sponsorship	NA	S.1311	NA	NA
+4145	Committee of Investigation for Great Britain	NA	S.1311	NA	NA
+4146	Committee on Agricultural Valuation	NA	S.1311	NA	NA
+4147	Committee on Appeals Criteria and Miscarriages of Justice	NA	S.1311	NA	NA
+4148	Committee on Carcinogenicity of Chemicals in Food, Consumer Products and the Environment	NA	S.1311	NA	NA
+1118	NA	government-organisation:PB196	S.1311	NA	NA
+4149	Committee on Medical Aspects of Food and Nutrition Policy	NA	S.1311	NA	NA
+4150	Committee on Medical Aspects of Radiation in the Environment	NA	S.1311	NA	NA
+1119	NA	government-organisation:PB526	S.1311	NA	NA
+4151	Committee on Products and Processes for use in Public Water Supply	NA	S.1311	NA	NA
+1120	NA	government-organisation:PB158	S.1311	NA	NA
+4152	Committee on the Medical Effects of Air Pollutants (DH)	NA	S.1311	NA	NA
+4153	Committee on the Safety of Medicines	NA	S.1311	NA	NA
+1121	NA	government-organisation:PB576	S.1311	NA	NA
+4154	Committees for the Employment of Disabled People	NA	S.1311	NA	NA
+4155	Common Services Agency of the Scottish Health Service (NHS National Services Scotland Board)	NA	S.1311	NA	NA
+4157	Commons Commissioners	NA	S.1311	NA	NA
+4158	Commonwealth Development Corporation	NA	S.12	NA	NA
+4159	Commonwealth Parliamentary Association (UK) Branch	NA	S.1311	2002-12-01	NA
+1122	NA	government-organisation:PB226	S.1311	NA	NA
+4160	Commonwealth War Graves Commission	NA	S.1311	NA	NA
+4161	Communications for Business	NA	S.1311	NA	NA
+4162	Communities Scotland	NA	S.1311	NA	2008-04-01
+4163	Community and Safety Services Limited	NA	S.11001	2009-07-28	NA
+4164	Community Councils (Scotland) (En Bloc)	NA	S.1313	1905-05-26	NA
+4165	Community Councils (Wales) (En Bloc)	NA	S.1313	1905-05-25	NA
+1123	NA	government-organisation:OT760	S.1311	NA	NA
+1124	NA	government-organisation:OT743	S.1311	NA	NA
+4167	Community Health Councils (En Bloc)	NA	S.1311	NA	2003-12-01
+4168	Community Health Councils (Wales)	NA	S.1311	NA	NA
+4169	Community Health Councils (Wales) Board	NA	S.1311	NA	NA
+4171	Community Learning Scotland	NA	S.1311	NA	NA
+4172	Community Safety Glasgow	NA	S.1313	2006-10-01	NA
+4173	Community Schools (En Bloc)	NA	S.1313	1999-11-01	NA
+1125	NA	government-organisation:EA26	S.11001	NA	NA
+4175	Compensation Agency (Northern Ireland)	NA	S.1311	NA	NA
+1126	NA	government-organisation:D550	S.1311	2013-10-01	NA
+1127	NA	government-organisation:PB140	S.1311	NA	NA
+1128	NA	government-organisation:PB353	S.1311	NA	NA
+1129	NA	government-organisation:PB318	S.1311	NA	NA
+4176	Compost Development Venture (CDV) Ltd	NA	S.1313	NA	NA
+4180	Conservation Board for the Chilterns Area of Outstanding Natural Beauty	NA	S.1313	2004-12-01	NA
+4181	Conservation Board for the Cotswolds Area of Outstanding Natural Beauty	NA	S.1313	2004-12-01	NA
+4182	Consignia (Customer Management) Limited	NA	S.11001	NA	NA
+4183	Consolidated Fund	NA	S.1311	NA	NA
+4184	Construction Industry Advisory Council (Northern Ireland)	NA	S.1311	NA	NA
+1721	NA	government-organisation:PB126	S.1311	NA	NA
+4185	Construction Industry Training Board, The	NA	S.1311	NA	NA
+4186	Construction Service	NA	S.1311	NA	NA
+4187	Consultative Board on Badgers and Bovine Tuberculosis	NA	S.1311	NA	NA
+4188	Consumer Communications for England (CCE)	NA	S.1311	NA	NA
+1757	NA	government-organisation:OT732	S.1311	NA	2008-04-01
+1130	NA	government-organisation:PB198	S.1311	NA	NA
+4189	Consumer Financial Education Body Ltd	NA	S.1311	2010-04-01	NA
+4190	Consumer Focus	NA	S.1311	2008-04-01	NA
+4191	Consumer Panel	NA	S.1311	NA	NA
+4192	Consumers’ Committee for Great Britain under the Agricultural Marketing Act 1958	NA	S.1311	NA	NA
+4193	Contingencies Fund	NA	S.1311	NA	NA
+4195	Contracts Rights Renewal Adjudicator	NA	S.1311	2003-12-01	NA
+4196	Contributions Agency	NA	S.1311	NA	NA
+4198	Conversion Loan Redemption Account	NA	S.1311	NA	NA
+1131	NA	principal-local-authority:CWY	S.1313	NA	NA
+1132	NA	local-authority-eng:COP	S.1313	NA	NA
+4207	Copyright Tribunal, The	NA	S.1311	NA	NA
+4208	Corby - (s NTC)	NA	S.1311	NA	NA
+1133	NA	local-authority-eng:COR	S.1313	NA	NA
+4213	Cornwall Airport	NA	S.1313	NA	NA
+1134	NA	local-authority-eng:CON	S.1313	NA	NA
+4215	Cornwall Housing Ltd	NA	S.11001	2010-04-01	NA
+4217	Coroners	NA	S.1313	NA	NA
+1135	NA	local-authority-eng:COT	S.1313	NA	NA
+1136	NA	government-organisation:OT778	S.1311	NA	NA
+1137	NA	government-organisation:OT814	S.1311	NA	NA
+4222	Council for National Academic Awards	NA	S.1311	NA	NA
+4223	Council for Nature Conservation and the Countryside	NA	S.1311	NA	NA
+4224	Council for Professions Supplementary to Medicine, the	NA	S.1311	NA	NA
+1138	NA	government-organisation:PB121	S.1311	NA	NA
+1714	NA	government-organisation:OT841	S.1311	NA	NA
+4225	Council for the Regulation of Healthcare Professionals	NA	S.1311	NA	NA
+4226	Council of Reserve Forces and Cadet Associations / Reserve Forces and Cadet Associations	NA	S.1311	NA	NA
+1139	NA	local-authority-eng:IOS	S.1313	NA	NA
+1140	NA	government-organisation:PB973	S.1311	NA	NA
+1141	NA	government-organisation:OT690	S.1311	NA	NA
+1142	NA	government-organisation:EA729	S.1311	NA	2006-10-01
+4228	Countryside Council for Wales	NA	S.1311	NA	2013-04-01
+4229	County Councils (En Bloc)	NA	S.1313	NA	NA
+4230	County Court Rule Committee	NA	S.1311	NA	NA
+4231	County Courts	NA	S.1311	NA	NA
+4232	County Durham Development Co Ltd	NA	S.1313	NA	NA
+4234	County Schools (En Bloc)	NA	S.1313	NA	NA
+4235	Court Funds Investment Account	NA	S.1311	NA	NA
+4236	Court Service, The	NA	S.1311	NA	2005-04-01
+4237	Coutts & Co	NA	S.12201	NA	NA
+1143	NA	government-organisation:OT214	S.11001	NA	NA
+4240	Coventry (Basington) Aerodrome	NA	S.1313	NA	NA
+1144	NA	local-authority-eng:COV	S.1313	NA	NA
+4242	Cowal Ferries Ltd	NA	S.1311	2007-04-01	NA
+1145	NA	local-authority-eng:CRA	S.1313	NA	NA
+1146	NA	local-authority-eng:CRW	S.1313	NA	NA
+1147	NA	government-organisation:OT964	S.1311	2010-07-01	NA
+4248	Crime Concern, Marks and Spencer, Groundwork Partnership (t/a Youth Works) (The)	NA	S.1311	NA	NA
+4249	Crime Prevention Agency Board	NA	S.1311	NA	NA
+1148	NA	government-organisation:IM320	S.1311	NA	NA
+1731	NA	government-organisation:OT837	S.1311	NA	2006-04-01
+1149	NA	government-organisation:PB297	S.1311	NA	NA
+1827	NA	government-organisation:EA829	S.1311	NA	NA
+1777	NA	government-organisation:OT772	S.1311	NA	NA
+1150	NA	government-organisation:PB516	S.1311	2004-01-01	NA
+1151	NA	government-organisation:OT726	S.1311	NA	2003-08-01
+4251	Crofting Commission (formerly Crofter's Commission)	NA	S.1311	NA	NA
+4252	Cromarty Firth	NA	S.11001	NA	2015-12-02
+4253	Cromarty Harbour	NA	S.11001	NA	2015-12-02
+4258	Cross London Rail Links Ltd	NA	S.1311	NA	NA
+4259	Crossrail Limited	NA	S.1313	NA	NA
+4260	Crown Agents for Overseas Governments and Administrations Ltd (known as Crown Agents)	NA	S.11001	NA	NA
+1152	NA	government-organisation:OT754	S.11001	NA	NA
+4261	Crown Court Rule Committee	NA	S.1311	NA	2012-09-01
+4262	Crown Courts (En Bloc)	NA	S.1311	NA	NA
+4263	Crown Estate	NA	S.11001	NA	NA
+4264	Crown Estate Paving Commission	NA	S.1313	NA	NA
+4265	Crown Office, Scotland	NA	S.1311	NA	NA
+1153	NA	government-organisation:D101	S.1311	NA	NA
+4267	Cruden Bay Harbour	NA	S.11001	NA	2015-12-02
+4269	CTRL (UK) Ltd	NA	S.11001	NA	2010-11-01
+4270	CTRL Section 1 Finance plc	NA	S.1311	2009-06-01	NA
+4272	Culture North East (North East Cultural Consortium)	NA	S.1311	NA	2010-09-01
+4273	Cumbernauld Development Corporation	NA	S.11001	NA	NA
+4275	Cumbria and Lancashire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1154	NA	local-authority-eng:CMA	S.1313	NA	NA
+4276	Cumbria Waste Disposal	NA	S.1313	NA	NA
+4280	Customer Service Committees (OFWAT)	NA	S.1311	NA	NA
+4282	Cwm Taf Health Board	NA	S.1311	2009-06-01	NA
+4283	Cwmbran - (s NTC)	NA	S.1311	NA	NA
+4288	Dacorum Council	NA	S.1313	NA	NA
+4289	Dairy Produce Quota Tribunal	NA	S.1311	NA	NA
+4290	DairyCo Ltd	NA	S.1311	NA	NA
+4292	Dale and Valley Homes Ltd	NA	S.11001	NA	NA
+1155	NA	local-authority-eng:DAL	S.1313	NA	NA
+1156	NA	local-authority-eng:DAR	S.1313	NA	NA
+1157	NA	government-organisation:OT217	S.1313	1996-06-01	NA
+4300	Dartmoor Steering Group and Working Party	NA	S.1311	NA	2006-04-01
+4301	Darwin Advisory Committee	NA	S.1311	NA	NA
+1158	NA	local-authority-eng:DAV	S.1313	NA	NA
+4304	David MacBrayne HR (UK) Ltd	NA	S.1311	2007-11-01	NA
+4305	David MacBrayne Ltd	NA	S.1311	2006-07-01	NA
+4309	Debt Management Account	NA	S.1311	NA	NA
+4310	Deer Commission for Scotland	NA	S.1311	NA	2011-04-01
+1159	NA	government-organisation:EA685	S.1311	NA	2008-04-01
+4311	Defence Animal Centre	NA	S.1311	NA	NA
+1160	NA	government-organisation:EA717	S.11001	NA	NA
+1161	NA	government-organisation:EA883	S.1311	NA	2007-04-01
+4312	Defence Codification Agency	NA	S.1311	NA	NA
+1787	NA	government-organisation:EA813	S.1311	NA	2007-04-01
+4313	Defence Dental Agency	NA	S.1311	NA	2005-04-01
+1162	NA	government-organisation:OT713	S.1311	NA	2007-04-01
+4314	Defence Estates Organisation	NA	S.1311	NA	NA
+4315	Defence Evaluation and Research Agency	NA	S.11001	NA	2001-07-01
+4316	Defence Geographical and Imaging Intelligence Agency	NA	S.1311	NA	2005-04-01
+4317	Defence Housing Executive	NA	S.1311	NA	2004-04-01
+1853	NA	government-organisation:OT720	S.1311	NA	2005-04-01
+4318	Defence Medical Training Organisation	NA	S.1311	NA	2008-04-01
+1163	NA	government-organisation:PB396	S.1311	NA	NA
+4319	Defence Postal and Courier Services Agency	NA	S.1311	NA	NA
+1164	NA	government-organisation:EA785	S.1311	NA	2007-04-01
+1751	NA	government-organisation:EA42	S.11001	NA	NA
+1165	NA	government-organisation:PB397	S.1311	NA	NA
+4320	Defence Secondary Care Agency	NA	S.1311	NA	2003-04-01
+1166	NA	government-organisation:EA789	S.1311	NA	2010-07-01
+1167	NA	government-organisation:EA44	S.11001	NA	NA
+4321	Defence Transport and Movement Executive	NA	S.1311	NA	2007-04-01
+1168	NA	government-organisation:EA884	S.1311	NA	2011-10-01
+4322	Defence, Clothing and Textiles Agency	NA	S.1311	NA	2010-07-01
+1169	NA	principal-local-authority:DEN	S.1313	NA	NA
+4324	Denehurst Park (Rochdale) Ltd	NA	S.1313	NA	NA
+1170	NA	government-organisation:OT798	S.1311	NA	NA
+4326	Dental Rates Study Group	NA	S.1311	NA	NA
+1171	NA	government-organisation:OT799	S.1311	NA	NA
+1798	NA	government-organisation:D1198	S.1311	2016-07-14	NA
+1823	NA	government-organisation:D611	S.1311	NA	NA
+1807	NA	government-organisation:D3	S.1311	NA	2016-07-14
+1719	NA	government-organisation:D609	S.1311	NA	NA
+1172	NA	government-organisation:D4	S.1311	NA	NA
+1730	NA	government-organisation:D587	S.1311	NA	2007-05-01
+4327	Department for Culture, Media & Sport	NA	S.1311	NA	NA
+1173	NA	government-organisation:D6	S.1311	NA	NA
+1174	NA	government-organisation:D854	S.1311	NA	NA
+4328	Department for Employment and Skills	NA	S.1311	NA	NA
+1175	NA	government-organisation:D7	S.1311	NA	NA
+1176	NA	government-organisation:D1197	S.1311	2016-07-14	NA
+1828	NA	government-organisation:D608	S.1311	NA	NA
+1177	NA	government-organisation:D8	S.1311	NA	NA
+1178	NA	government-organisation:D1196	S.1311	2016-07-14	NA
+1179	NA	government-organisation:D9	S.1311	NA	NA
+4329	Department for Transport, Local Government and the Regions (DTLR)	NA	S.1311	NA	NA
+1180	NA	government-organisation:D10	S.1311	NA	NA
+1819	NA	government-organisation:D11	S.1311	NA	2016-07-14
+1181	NA	government-organisation:D12	S.1311	NA	NA
+1733	NA	government-organisation:D586	S.1311	NA	NA
+1182	NA	local-authority-eng:DER	S.1313	NA	NA
+4333	Derby Homes Ltd	NA	S.11001	NA	NA
+1183	NA	local-authority-eng:DBY	S.1313	NA	NA
+1184	NA	local-authority-eng:DEB	S.1313	NA	NA
+4334	Derbyshire, Nottinghamshire, Leicestershire & Rutland Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+4335	Derry City and Strabane District Council	NA	S.1313	NA	NA
+4342	Design Council (incorporating CABE)	NA	S.1311	NA	2011-04-01
+4345	Developing Initiatives for Support in the Community	NA	S.11001	NA	NA
+4346	Development Awareness Working Group	NA	S.1311	NA	2001-04-01
+4347	Development Board for Rural Wales	NA	S.11001	NA	NA
+4348	Development Initiative for Slough Housing	NA	S.1313	NA	NA
+1185	NA	local-authority-eng:DEV	S.1313	NA	NA
+4350	Devon Waste Management Limited	NA	S.11001	NA	2003-12-01
+4351	Diamond Light Source Limited	NA	S.1311	2002-02-01	NA
+4352	Diceform Ltd  - (s Remploy Ltd)	NA	S.11001	NA	NA
+4355	Diplomatic Service Appeal Board	NA	S.1311	NA	2011-03-01
+4356	Direct Labour Organisations (En Bloc)	NA	S.1313	NA	NA
+4357	Direct Line Group	NA	S.12801	NA	2013-09-01
+4358	Direct Rail Services Ltd	NA	S.11001	NA	NA
+4359	Direct Service Organisations	NA	S.1313	NA	NA
+1760	NA	government-organisation:PB459	S.1311	NA	NA
+4360	Disability Employment Advisory Committee	NA	S.1311	NA	2008-04-01
+4361	Disability Living Allowance Advisory Board	NA	S.1311	NA	2013-02-01
+4362	Disability Living Allowance Advisory Board for Northern Ireland	NA	S.1311	NA	NA
+1186	NA	government-organisation:OT711	S.1311	NA	NA
+4363	Disability Rights Task Force	NA	S.1311	NA	NA
+1736	NA	government-organisation:PB1152	S.1311	2015-04-07	NA
+1729	NA	government-organisation:PB247	S.1311	NA	NA
+1187	NA	government-organisation:PB509	S.1311	2012-12-01	NA
+1188	NA	government-organisation:EA823	S.1311	NA	2007-04-01
+4364	Distinction and Meritorious Service Awards Committee	NA	S.1311	NA	NA
+4365	District Councils	NA	S.1313	NA	NA
+4367	DoA Ltd	NA	S.1311	NA	2012-07-01
+4368	Docklands Light Railway Ltd (s.TfL)	NA	S.11001	NA	NA
+4369	Doctors’ and Dentists’ Review Body	NA	S.1311	NA	NA
+4370	Dolerite Funding No.1 plc	NA	S.12501	NA	NA
+4371	Dolerite Funding No.2 plc	NA	S.12501	NA	NA
+4373	Domestic Coal Consumers' Council	NA	S.1311	NA	NA
+4374	Dominican Playgroup	NA	S.1313	NA	NA
+4375	Donations and Bequests (to government)	NA	S.1311	NA	NA
+1189	NA	local-authority-eng:DNC	S.1313	NA	NA
+4379	Dorneywood Trust	NA	S.1311	NA	NA
+4380	Dornoch Aerodrome	NA	S.1313	NA	NA
+1190	NA	local-authority-eng:DOR	S.1313	NA	NA
+4381	Dorset, Devon & Cornwall Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+4382	Dounreay Site Restoration Limited	NA	S.1311	2008-04-01	NA
+1191	NA	local-authority-eng:DOV	S.1313	NA	NA
+4383	Dover Harbour Board	NA	S.11001	NA	NA
+4384	Drainage Council for Northern Ireland	NA	S.1311	NA	NA
+4387	Driver & Vehicle Agency (Northern Ireland)	NA	S.11001	NA	NA
+1734	NA	government-organisation:EA74	S.1311	NA	NA
+1192	NA	government-organisation:EA75	S.11001	NA	NA
+1193	NA	local-authority-eng:DUD	S.1313	NA	NA
+4392	Duke of York’s Military School	NA	S.1311	NA	2007-04-01
+1830	NA	local-authority-sct:DGY	S.1313	NA	NA
+4394	Dumfries and Galloway Regional Council Harbour	NA	S.1313	NA	NA
+4395	Dunbar Harbour	NA	S.11001	NA	2015-12-02
+4396	Dunbar Port	NA	S.1313	NA	NA
+4398	Dundee Aerodrome	NA	S.1313	NA	2007-12-01
+1877	NA	local-authority-sct:DND	S.1313	NA	NA
+4401	Dunstaffnage Marine Laboratory	NA	S.1311	NA	NA
+1194	NA	local-authority-eng:DUR	S.1313	NA	NA
+4404	Durham Tees Valley Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+4407	Ealing Homes Ltd	NA	S.11001	NA	2012-11-01
+1865	NA	local-authority-sct:EAY	S.1313	NA	NA
+1195	NA	local-authority-eng:ECA	S.1313	NA	NA
+4411	East Coast Main Line Company Ltd	NA	S.11001	NA	2015-03-01
+1196	NA	local-authority-eng:EDE	S.1313	NA	NA
+1197	NA	local-authority-eng:EDO	S.1313	NA	NA
+1834	NA	local-authority-sct:EDU	S.1313	NA	NA
+4412	East Dunbartonshire Municipal Bank Ltd	NA	S.12501	NA	NA
+4414	East Durham Homes Ltd	NA	S.11001	NA	NA
+1198	NA	local-authority-eng:EHA	S.1313	NA	NA
+1199	NA	local-authority-eng:EHE	S.1313	NA	NA
+4417	East Kent Housing	NA	S.11001	2011-04-01	NA
+4419	East Lancashire Light Railway Trust	NA	S.1313	NA	NA
+1200	NA	local-authority-eng:ELI	S.1313	NA	NA
+4420	East London Waste Authority	NA	S.1313	1986-01-01	NA
+1870	NA	local-authority-sct:ELN	S.1313	NA	NA
+4422	East Midlands Airport (s MA)	NA	S.11001/3	2013-02-01	NA
+4423	East Midlands Airport Nottingham Derby Leicester Ltd	NA	S.11001/3	2013-02-01	NA
+4424	East Midlands Airport Property Investments (Hotels) Ltd	NA	S.11001/3	2013-02-01	NA
+4425	East Midlands Airport Property Investments (Industrial) Ltd	NA	S.11001/3	2013-02-01	NA
+4426	East Midlands Airport Property Investments (Offices) Ltd	NA	S.11001/3	2013-02-01	NA
+4427	East Midlands Cultural Consortium	NA	S.1311	NA	2010-09-01
+1740	NA	government-organisation:EA912	S.1311	NA	2012-07-01
+4429	East Midlands International Airport	NA	S.11001	NA	NA
+4430	East Midlands Region: Electricity Consumers Committee	NA	S.1311	NA	NA
+4431	East North East Homes Leeds	NA	S.11001	NA	NA
+1201	NA	local-authority-eng:ENO	S.1313	NA	NA
+1202	NA	government-organisation:EA917	S.1311	NA	2012-07-01
+4432	East of England International Ltd	NA	S.1311	NA	2012-06-21
+4433	East of Scotland Water Authority	NA	S.11001	NA	NA
+1838	NA	local-authority-sct:ERW	S.1313	NA	NA
+1203	NA	local-authority-eng:ERY	S.1313	NA	NA
+1204	NA	local-authority-eng:EST	S.1313	NA	NA
+1205	NA	local-authority-eng:ESX	S.1313	NA	NA
+1206	NA	local-authority-eng:EAS	S.1313	NA	NA
+4436	Eastbourne Buses Ltd	NA	S.11001	NA	2008-12-01
+4437	Eastbourne Homes Ltd	NA	S.11001	NA	NA
+1859	NA	government-organisation:OT865	S.1311	NA	NA
+4438	Eastern Region: Electricity Consumers’ Committee	NA	S.1311	NA	NA
+4439	Eastern Shires Purchasing Organisation	NA	S.11001	NA	NA
+1207	NA	local-authority-eng:EAT	S.1313	NA	NA
+4443	Eblex Ltd	NA	S.1311	NA	NA
+1722	NA	government-organisation:PB129	S.1311	NA	NA
+4446	Economic Research Institute of Northern Ireland	NA	S.1311	NA	NA
+4447	Eday Aerodrome	NA	S.1313	NA	NA
+1208	NA	local-authority-eng:EDN	S.1313	NA	NA
+4449	Edinburgh City Council	NA	S.1313	NA	NA
+4450	Edinburgh International Conference Centre Ltd	NA	S.1313	NA	NA
+4451	Edinburgh Tours Ltd	NA	S.11001	NA	NA
+4452	Education Action Fora	NA	S.1313	NA	NA
+1209	NA	government-organisation:EA242	S.1311	2012-04-01	NA
+4453	Education Leeds Ltd	NA	S.1313	NA	NA
+4454	Education Scotland	NA	S.1311	2011-04-01	NA
+4455	Education Transfer Council (ETC)	NA	S.1311	NA	NA
+4460	Eileen Trust	NA	S.1311	NA	NA
+1871	NA	government-organisation:IM1203	S.1311	NA	NA
+4467	Electricity Council	NA	S.1311	NA	NA
+4468	Electricity Producers Insurance Co. Ltd	NA	S.11001	NA	NA
+4469	Electricity Settlements Company Ltd	NA	S.1311	2014-08-01	NA
+1210	NA	local-authority-eng:ELM	S.1313	NA	NA
+4477	Employment Service	NA	S.1311	NA	2002-04-01
+4478	Employment Tribunals Service	NA	S.1311	NA	2006-04-01
+4482	Energy Advisory Panel	NA	S.1311	NA	NA
+4483	Energy Sales and Trading Ltd (s. BNFL)	NA	S.11001	NA	2007-04-01
+4484	Enfield Homes Ltd	NA	S.11001	NA	NA
+1712	NA	government-organisation:PB130	S.1311	NA	NA
+1211	NA	government-organisation:PB131	S.1311	NA	NA
+4485	England Marketing Advisory Board	NA	S.1311	NA	NA
+1825	NA	government-organisation:OT957	S.1311	2002-04-01	NA
+4486	English National Board for Nursing, Midwifery and Health Visiting	NA	S.1311	NA	NA
+1212	NA	government-organisation:EA833	S.1311	NA	NA
+4487	English Partnerships (LP) Limited	NA	S.1311	NA	NA
+4489	English Tourism Council	NA	S.1311	NA	NA
+4491	Enniskillen Aerodrome	NA	S.1313	NA	NA
+4492	Enrichment Holdings Limited	NA	S.1311	2008-03-01	NA
+4493	Enrichment Investments Limited	NA	S.1311	2009-12-01	NA
+4494	Enterprise South Devon	NA	S.1313	NA	NA
+1213	NA	government-organisation:OT871	S.1311	NA	NA
+1214	NA	government-organisation:EA199	S.1311	NA	NA
+1215	NA	government-organisation:EA788	S.1311	NA	2008-07-01
+1216	NA	local-authority-eng:EPP	S.1313	NA	NA
+1217	NA	local-authority-eng:EPS	S.1313	NA	NA
+1771	NA	government-organisation:OT710	S.1311	NA	NA
+1218	NA	government-organisation:PB230	S.1311	2006-12-01	NA
+1219	NA	government-organisation:OT269	S.1311	NA	NA
+1220	NA	government-organisation:OT779	S.1311	NA	NA
+1221	NA	local-authority-eng:ERE	S.1313	NA	NA
+4498	Essex Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1222	NA	local-authority-eng:ESS	S.1313	NA	NA
+4500	Ethnic Minority Business Forum	NA	S.1311	NA	NA
+4501	Euro-Hub (Birmingham)	NA	S.1313	NA	NA
+4502	European Channel Broadcasting Ltd (s BBCW)	NA	S.11001	NA	NA
+4503	European Channel Management Ltd (s BBCW)	NA	S.11001	NA	NA
+4504	Eurostar (UK) Ltd	NA	S.11001	NA	2010-09-01
+4512	Exchange Equalisation Account	NA	S.1311	NA	NA
+4513	Exeter and Devon Airport Ltd	NA	S.11001	NA	NA
+1223	NA	local-authority-eng:EXE	S.1313	NA	NA
+1224	NA	government-organisation:OT219	S.1313	1996-06-01	NA
+4516	Expert Advisory Group on AIDS	NA	S.1311	NA	NA
+4517	Expert Group on Cryptosporidium in Water Supplies	NA	S.1311	NA	NA
+4518	Expert Group on Vitamins and Minerals	NA	S.1311	NA	NA
+4519	Expert Panel on Air Quality Standards	NA	S.1311	NA	NA
+4520	Export Action Group for Building Materials	NA	S.1311	NA	NA
+4521	Export Credits Guarantee Department	NA	S.12	NA	NA
+1225	NA	government-organisation:PB357	S.1311	NA	NA
+4522	Extra Parliamentary Panel	NA	S.1311	NA	NA
+4524	Eyemouth Harbour	NA	S.11001	NA	2015-12-02
+4525	F2 Chemicals Ltd - (s BNFL)	NA	S.11001	NA	NA
+4526	F2 Chemicals Pension Trustee Co. Ltd (s BNFL Fl Ltd)	NA	S.11001	NA	NA
+4528	Fair Employment Commission for Northern Ireland	NA	S.1311	NA	NA
+4529	Fair Employment Tribunal	NA	S.1311	NA	NA
+4532	Fairfields Art Centre Trust	NA	S.1313	NA	NA
+4537	Falkirk Council	NA	S.1313	NA	NA
+4538	Falmouth Harbour Commissioners	NA	S.11001	NA	NA
+1226	NA	government-organisation:OT691	S.1311	NA	2005-04-01
+4539	Family Health Services Appeal Authority (Tribunal)	NA	S.1311	NA	2010-01-01
+4545	Family Practitioner Committees	NA	S.1311	NA	NA
+1227	NA	government-organisation:PB442	S.1311	NA	NA
+1228	NA	local-authority-eng:FAR	S.1313	NA	NA
+4546	Farm Animal Welfare Council	NA	S.1311	NA	2011-03-01
+1229	NA	government-organisation:EA61	S.11001	2006-04-01	NA
+4549	FE Improvement Ltd	NA	S.1311	NA	2008-06-01
+4551	Fellside Heat and Power Ltd (s. BNG / BNFL)	NA	S.11001	NA	NA
+1230	NA	local-authority-eng:FEN	S.1313	NA	NA
+4555	Fermanagh and Omagh District Council	NA	S.1313	NA	NA
+4557	FHS Appeals Authority	NA	S.1311	NA	NA
+4559	Fieldwealth Ltd - (s LDDC)	NA	S.11001	NA	NA
+4560	Fife Council	NA	S.1313	NA	NA
+4562	Fife Regional Council Harbour	NA	S.1313	NA	NA
+4563	FilmFour Ltd - (s C4)	NA	S.11001	NA	NA
+4564	Finance Wales Investments (2) Ltd	NA	S.12501	NA	NA
+4565	Finance Wales Investments Ltd	NA	S.12501	NA	NA
+4566	Finance Wales Plc	NA	S.1311	NA	NA
+1231	NA	government-organisation:OT1085	S.12601	2013-04-01	NA
+4567	Financial Ombudsman Service	NA	S.12601	NA	NA
+4568	Financial Reporting Advisory Board	NA	S.1311	NA	NA
+4569	Financial Reporting Council, The	NA	S.1311	NA	NA
+4570	Financial Services and Markets Appeal Tribunal	NA	S.1311	NA	NA
+4571	Financial Services Authority	NA	S.12601	NA	2013-04-01
+4572	Financial Services Compensation Scheme	NA	S.1311	NA	NA
+4573	Financial Services Tribunal	NA	S.1311	NA	NA
+4577	Fire and Civil Defence Authorities (En Bloc)	NA	S.1313	NA	NA
+4578	Fire and Rescue Authorities (En Bloc)	NA	S.1313	2004-10-01	NA
+4579	Fire and Rescue Authorities (Scotland) (En Bloc)	NA	S.1313	NA	2013-04-01
+4580	Fire and Rescue Services (England and Wales) (En Bloc)	NA	S.1313	NA	NA
+4581	Fire and Rescue Services (Scotland) (En Bloc)	NA	S.1313	NA	2013-04-01
+1232	NA	government-organisation:OT759	S.1311	NA	2006-07-01
+1233	NA	government-organisation:EA37	S.11001	NA	NA
+1234	NA	government-organisation:OT588	S.1311	NA	NA
+1235	NA	government-organisation:OT961	S.1311	NA	2011-04-01
+4582	Firesmart Ltd - (s LDDC)	NA	S.11001	NA	NA
+4584	First Choice Homes Oldham Ltd	NA	S.11001	NA	2011-02-01
+4587	First Rate Exchange Services Holdings Limited	NA	S.12601	1905-06-24	NA
+4588	First Rate Exchange Services Limited	NA	S.12601	1905-06-24	NA
+1236	NA	government-organisation:OT807	S.1311	NA	2009-06-01
+4590	Fisheries Research Agency	NA	S.1311	NA	NA
+4591	Fisheries Research Services	NA	S.1311	NA	2009-04-01
+4596	Flamborough (North Sea Landing) Harbour Commissioners	NA	S.11001	NA	NA
+1237	NA	government-organisation:PB311	S.11001	NA	NA
+4597	Flexibus Ltd - (s NITHC)	NA	S.11001	NA	2008-09-01
+1238	NA	principal-local-authority:FLN	S.1313	NA	NA
+4599	Fluorochem Ltd - (s BNFL F2 Ltd)	NA	S.11001	NA	NA
+4600	Folkestone Sports Centre Trust Ltd	NA	S.1313	NA	NA
+4601	Food Advisory Committee	NA	S.1311	NA	NA
+1880	NA	government-organisation:EA56	S.1311	NA	2015-03-31
+1239	NA	government-organisation:OT793	S.1.311	NA	NA
+1240	NA	government-organisation:D102	S.1311	NA	NA
+4602	Food Standards Scotland	NA	S.1311	2015-04-01	NA
+1241	NA	government-organisation:OT787	S.1311	NA	NA
+4603	Football Taskforce	NA	S.1311	NA	NA
+1242	NA	government-organisation:D13	S.1311	NA	NA
+1243	NA	government-organisation:PB257	S.1311	NA	2013-03-01
+1244	NA	government-organisation:OT812	S.11001	NA	NA
+4606	Forensic Science Service Northern Ireland	NA	S.1311	NA	NA
+4607	Foresight Steering Group	NA	S.1311	NA	2001-04-01
+1803	NA	government-organisation:EA55	S.11001	NA	NA
+4608	Forest Enterprise Scotland	NA	S.11001	NA	NA
+4609	Forest Enterprise Wales	NA	S.11001	NA	2004-04-01
+1245	NA	local-authority-eng:FOR	S.1313	NA	NA
+1246	NA	local-authority-eng:FOE	S.1313	NA	NA
+1247	NA	government-organisation:EA54	S.1311	NA	NA
+1248	NA	government-organisation:D85	S.1311	NA	NA
+4613	Forth Estuary Transport Authority	NA	S.1311	2008-02-01	2015-04-30
+4615	Forth Road Bridge Joint Board	NA	S.11001	NA	2002-04-01
+4622	Foundation Schools (and Foundation Special Schools) (En Bloc)	NA	S.1313	2010-05-01	NA
+4624	Foyle Fisheries Commission	NA	S.1311	NA	NA
+4625	Foyle, Carlingford and Irish Lights Commission	NA	S.1311	1999-12-01	NA
+4631	Fraserburgh Harbour	NA	S.11001	NA	2015-12-02
+4632	Free Schools (En Bloc)	NA	S.1311	NA	NA
+4640	Fuel Cells Advisory Panel	NA	S.1311	NA	NA
+4642	Funding Agency for Schools	NA	S.1311	NA	NA
+4643	Furness Enterprise Ltd	NA	S.1313	NA	NA
+4644	Further Education Corporations in England (En Bloc)	NA	S.1311	NA	2012-04-01
+4645	Further Education Funding Council (FEFC)	NA	S.1311	NA	NA
+1876	NA	government-organisation:OT1000	S.1311	NA	NA
+1249	NA	local-authority-eng:FYL	S.1313	NA	NA
+4650	Galleon Ltd (s BBCW)	NA	S.11001	NA	2013-05-01
+1250	NA	government-organisation:PB169	S.1311	NA	NA
+1251	NA	government-organisation:OT626	S.1311	NA	NA
+1252	NA	government-organisation:PB200	S.1311	2005-04-01	NA
+4653	Gardenstown Harbour	NA	S.11001	NA	2015-12-02
+1789	NA	government-organisation:OT733	S.1311	NA	2008-04-01
+4655	Gateshead Council	NA	S.1313	NA	NA
+4656	Gateshead Housing Company	NA	S.11001	NA	NA
+1253	NA	local-authority-eng:GED	S.1313	NA	NA
+4659	Geffrye Museum Trust Ltd	NA	S.1311	NA	NA
+4661	Gene Therapy Advisory Committee	NA	S.1311	NA	NA
+4662	General Commissioners of Income Tax (GCIT)	NA	S.1311	NA	NA
+1254	NA	government-organisation:OT809	S.1311	NA	NA
+4663	General Lighthouse Fund	NA	S.1311	1905-04-29	NA
+4664	General Register Office for Scotland (GROS)	NA	S.1311	NA	2011-04-01
+1255	NA	government-organisation:OT741	S.1311	NA	2012-10-01
+1256	NA	government-organisation:EA715	S.1311	NA	2012-04-01
+4665	General Teaching Council for Northern Ireland	NA	S.1311	1905-06-24	NA
+4666	General Teaching Council for Scotland	NA	S.1311	1905-06-24	NA
+4667	General Teaching Council for Wales	NA	S.1311	1905-06-22	NA
+4669	Genetics and Insurance Committee	NA	S.1311	NA	NA
+4678	Glasgow 2014 Ltd	NA	S.1311	2007-06-01	NA
+1872	NA	local-authority-sct:GLG	S.1313	NA	NA
+4680	Glasgow Prestwick Airport Limited	NA	S.11001	2013-11-22	NA
+4686	Glenforsa Aerodrome	NA	S.1313	NA	NA
+4688	Globe Enterprises Ltd	NA	S.1313	NA	NA
+1257	NA	local-authority-eng:GLO	S.1313	NA	NA
+4691	Gloucester/Cheltenham (Staverton) Aerodrome	NA	S.1313	NA	NA
+4692	Gloucestershire Airport Ltd	NA	S.11001	NA	NA
+1258	NA	local-authority-eng:GLS	S.1313	NA	NA
+1259	NA	local-authority-eng:GOS	S.1313	NA	NA
+1260	NA	government-organisation:D103	S.1311	NA	NA
+4706	Government Annuities Investment Fund	NA	S.1311	NA	NA
+1261	NA	government-organisation:EA830	S.1311	NA	2012-10-01
+1262	NA	government-organisation:OT306	S.1311	NA	NA
+1263	NA	government-organisation:OT506	S.1311	NA	2011-04-01
+4707	Government Hospitality Fund Advisory Committee for the Purchase of Wine	NA	S.1311	NA	2010-10-01
+1264	NA	government-organisation:D1108	S.1311	NA	NA
+1265	NA	government-organisation:EA365	S.11001	2011-07-01	NA
+4708	Government Property Lawyers	NA	S.1311	NA	NA
+4709	Government Purchasing Agency (Northern Ireland)	NA	S.1311	NA	NA
+4710	Government-Industry Forum on non-food uses of crops	NA	S.1311	NA	NA
+4714	Grampian Regional Council Harbour	NA	S.1313	NA	NA
+4720	Granite Finance Funding 2 Limited	NA	S.12501	NA	NA
+4721	Granite Master Issuer plc	NA	S.12501	NA	NA
+4722	Granite Mortgages 01-1 plc	NA	S.12501	NA	NA
+4723	Granite Mortgages 01-2 plc	NA	S.12501	NA	NA
+4724	Granite Mortgages 02-1 plc	NA	S.12501	NA	NA
+4725	Granite Mortgages 02-2 plc	NA	S.12501	NA	NA
+4726	Granite Mortgages 03-1 plc	NA	S.12501	NA	NA
+4727	Granite Mortgages 03-2 plc	NA	S.12501	NA	NA
+4728	Granite Mortgages 03-3 plc	NA	S.12501	NA	NA
+4729	Granite Mortgages 04-1 plc	NA	S.12501	NA	NA
+4730	Granite Mortgages 04-2 plc	NA	S.12501	NA	NA
+4731	Granite Mortgages 04-3 plc	NA	S.12501	NA	NA
+4732	Grant Maintained Schools (En Bloc)	NA	S.1311	NA	NA
+1266	NA	local-authority-eng:GRA	S.1313	NA	NA
+4736	Great North Eastern Railway (GNER) Ltd	NA	S.11001	NA	2007-12-01
+1267	NA	local-authority-eng:GRY	S.1313	NA	NA
+4740	Great Yarmouth Transport Ltd	NA	S.11001	NA	2002-05-01
+1268	NA	local-authority-eng:GLA	S.1313	NA	NA
+4741	Greater London Magistrates Court Authority	NA	S.1313	NA	2005-04-01
+4742	Greater Manchester Combined Authority	NA	S.1313	NA	NA
+4743	Greater Manchester Integrated Transport Authority	NA	S.1313	NA	NA
+4744	Greater Manchester Lieutenancy	NA	S.1313	NA	NA
+4745	Greater Manchester Passenger Transport Executive	NA	S.11001	NA	NA
+4746	Greater Manchester Passenger Transport Executive - (s PTE)	NA	S.1313	NA	1998-04-01
+4747	Greater Manchester Sites Ltd	NA	S.1313	NA	NA
+4748	Greater Manchester Waste Disposal Authority	NA	S.1313	NA	NA
+4749	Greater Nottingham Rapid Transit Ltd	NA	S.1313	NA	NA
+4750	Green Dragon AudioVisual Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+4757	Greenwich Hospital	NA	S.11001	NA	NA
+1269	NA	government-organisation:OT551	S.1311	2013-06-01	NA
+4760	Groundwork Trusts (En Bloc)	NA	S.1311	NA	NA
+4761	Groundwork UK	NA	S.1311	NA	NA
+4764	Guaranteed Export Finance Corporation PLC (GEFCo)	NA	S.12601	NA	NA
+4765	Guaranteed Export Financing Corporation (GEFCo) *	NA	S.1311	NA	NA
+1270	NA	local-authority-eng:GRT	S.1313	NA	NA
+4774	Gwent Careers Service Partnership	NA	S.1311	2013-04-01	NA
+4775	Gwynedd County Council	NA	S.1313	NA	NA
+4777	Gyrfa Cymru Gogledd Orllewin Cyfyngedig	NA	S.1311	2013-04-01	NA
+4778	H&F Homes Ltd	NA	S.11001	NA	2011-04-01
+4781	Hackney Homes Ltd	NA	S.11001	NA	NA
+1271	NA	local-authority-eng:HAL	S.1313	NA	NA
+4788	Halton Borough Transport	NA	S.11001	NA	NA
+1272	NA	local-authority-eng:HAE	S.1313	NA	NA
+4793	Hampshire & Isle of Wight Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1273	NA	local-authority-eng:HAM	S.1313	NA	NA
+4796	Hannah Research Institute	NA	S.1311	NA	2006-04-01
+1274	NA	local-authority-eng:HAO	S.1313	NA	NA
+4805	Harlow - (s NTC)	NA	S.1311	NA	NA
+1275	NA	local-authority-eng:HAR	S.1313	NA	NA
+1276	NA	local-authority-eng:HAG	S.1313	NA	NA
+1277	NA	local-authority-eng:HAT	S.1313	NA	NA
+1278	NA	local-authority-eng:HPL	S.1313	NA	NA
+4816	Harwich Haven Authority	NA	S.11001	NA	NA
+1279	NA	local-authority-eng:HAS	S.1313	NA	NA
+4821	Hatfield - (s NTC)	NA	S.1311	NA	NA
+1280	NA	local-authority-eng:HAA	S.1313	NA	NA
+4825	Haverfordwest Aerodrome	NA	S.1313	NA	NA
+4826	Haverfordwest Port	NA	S.1313	NA	NA
+4832	Health Advisory Service	NA	S.1311	NA	NA
+4833	Health and Care Professions Council	NA	S.1311	2012-08-01	NA
+4834	Health and Safety Agency for Northern Ireland	NA	S.1311	NA	NA
+4835	Health and Safety Commission	NA	S.1311	NA	2008-04-01
+1281	NA	government-organisation:PB207	S.1311	NA	NA
+4836	Health and Safety Executive for Northern Ireland	NA	S.1311	NA	NA
+1282	NA	government-organisation:OT538	S.1311	2005-04-01	NA
+4837	Health and Social Care Regulation and Quality Improvement Authority (Northern Ireland), The	NA	S.1311	2009-04-01	NA
+4838	Health and Social Care Trusts (Northern Ireland) (En Bloc)	NA	S.1311	2010-04-01	NA
+4839	Health and Social Services Boards (Northern Ireland) (En Bloc)	NA	S.1311	NA	2009-04-01
+4840	Health and Social Services Councils (Northern Ireland) (En Bloc)	NA	S.1311	NA	2009-04-01
+4841	Health and Social Services Trusts	NA	S.1311	NA	2009-04-01
+4842	Health Appointments Advisory Committee	NA	S.1311	NA	2001-06-01
+4843	Health Authorities (England) (En Bloc)	NA	S.1311	NA	2002-10-01
+4844	Health Authorities (Wales) (En Bloc)	NA	S.1311	NA	2003-04-01
+4845	Health Boards (Scotland) (En Bloc)	NA	S.1311	NA	NA
+4846	Health Commission Wales	NA	S.1311	NA	2010-04-01
+4847	Health Development Agency	NA	S.1311	NA	2005-04-01
+4848	Health Education Authority	NA	S.1311	NA	NA
+2601	Health Education Board for Scotland	NA	S.1311	NA	2003-04-01
+1283	NA	government-organisation:OT539	S.1311	2012-06-01	NA
+2602	Health Estates (Northern Ireland)	NA	S.1311	NA	NA
+2603	Health Promotion Authority for Wales	NA	S.1311	NA	NA
+1284	NA	government-organisation:EA792	S.1311	NA	2013-04-01
+1285	NA	government-organisation:OT483	S.1311	2011-12-01	NA
+2604	Health Technology Board for Scotland	NA	S.1311	NA	2003-01-01
+1286	NA	government-organisation:OT889	S.1311	NA	2009-03-01
+2605	Healthcare Improvement Scotland	NA	S.1311	2010-04-01	NA
+2606	Healthwatch England	NA	S.1311	2013-04-01	NA
+1287	NA	government-organisation:OT724	S.11001	NA	2010-07-01
+2613	Heeley City Farm Ltd	NA	S.1313	NA	NA
+2616	Helensburgh Port	NA	S.1313	NA	NA
+2618	Hemel Hempstead - (s NTC)	NA	S.1311	NA	NA
+2627	NA	government-organisation:EA601	S.1311	NA	2011-04-01
+2628	NA	government-organisation:EA73	S.1311	2011-04-01	NA
+1888	NA	government-organisation:OT347	S.1311	NA	NA
+2629	NA	government-organisation:OT742	S.1311	NA	NA
+2630	Her Majesty's Passport Service	NA	S.1311	2013-05-01	NA
+2631	NA	government-organisation:EA321	S.1311	NA	NA
+2632	NA	government-organisation:D25	S.1311	NA	NA
+2633	NA	government-organisation:D15	S.1311	NA	NA
+1288	NA	local-authority-eng:HEF	S.1313	NA	NA
+1778	NA	government-organisation:PC390	S.1311	NA	NA
+2636	Hertfordshire Career Services Ltd	NA	S.1313	NA	NA
+1289	NA	local-authority-eng:HRT	S.1313	NA	NA
+1290	NA	local-authority-eng:HER	S.1313	NA	NA
+2642	HGCA Ltd	NA	S.1311	NA	NA
+1291	NA	local-authority-eng:HIG	S.1313	NA	NA
+2647	High Peak Community Housing Ltd	NA	S.11001	NA	2013-05-01
+1292	NA	government-organisation:PB460	S.1311	2009-01-01	NA
+1293	NA	government-organisation:PB120	S.1311	NA	NA
+2648	Higher Education Funding Council for Wales	NA	S.1311	NA	NA
+2649	NA	local-authority-sct:HLD	S.1313	NA	NA
+2650	Highland Regional Council Harbour	NA	S.1313	NA	NA
+2651	Highlands & Islands Enterprise	NA	S.11001	NA	NA
+2652	Highlands and Islands Airports	NA	S.11001	NA	NA
+2653	Highlands and Islands Airports Ltd	NA	S.1311	NA	NA
+2654	Highlands and Islands Enterprise	NA	S.1311	NA	NA
+2655	Highlands and Islands Transport Partnership (HITRANS)	NA	S.1313	2005-12-01	NA
+1294	NA	government-organisation:EA77	S.1311	NA	NA
+2658	Hill Farming Advisory Committee for England, Wales and Northern Ireland (HFAC)	NA	S.1311	NA	NA
+2659	Hill Farming Advisory Committee for Scotland	NA	S.1311	NA	1905-06-24
+2660	Hill Farming Advisory Sub-Committee for Wales	NA	S.1311	NA	NA
+2665	Hillingdon Homes Ltd	NA	S.11001	NA	2010-10-01
+1295	NA	local-authority-eng:HIN	S.1313	NA	NA
+2668	Historic Buildings Council for England	NA	S.1311	NA	1905-06-06
+2669	Historic Buildings Council for Northern Ireland	NA	S.1311	1905-05-27	NA
+2670	Historic Buildings Council for Scotland	NA	S.1311	NA	2003-06-01
+2671	Historic Buildings Council for Wales	NA	S.1311	NA	2006-04-01
+2672	NA	government-organisation:PB1164	S.1311	2014-11-24	NA
+2673	Historic Environment Advisory Council	NA	S.1311	NA	2010-07-01
+2674	Historic Environment Scotland	NA	S.1311	2015-10-01	NA
+2675	Historic Monuments Council (Northern Ireland)	NA	S.1311	NA	NA
+2676	NA	government-organisation:PC389	S.11001	NA	NA
+1758	NA	government-organisation:PC389	S.11001	NA	NA
+2677	Historic Scotland	NA	S.1311	NA	2015-04-01
+2678	Historical Manuscripts Commission (The Royal Commission on Historical Manuscripts)	NA	S.1311	NA	NA
+1846	HM Inspectorate of Education	NA	S.1311	NA	2011-04-01
+2680	HM Treasury UK Sovereign Sukuk Plc	NA	S.1311	2014-05-01	NA
+2681	Hobart Investments Ltd (HI) - (s BCC)	NA	S.11001	NA	NA
+2688	Holywell Trust	NA	S.1313	NA	NA
+1296	NA	government-organisation:D16	S.1311	NA	NA
+2692	Home Service Group (HS) - (s BBC)	NA	S.11001	NA	NA
+1297	NA	government-organisation:OT757	S.1311	NA	NA
+1298	NA	government-organisation:PB161	S.1311	NA	NA
+2696	Homes for Haringey Ltd	NA	S.11001	NA	NA
+2697	Homes for Islington Ltd	NA	S.11001	NA	2012-04-01
+2699	Homes for Northumberland Ltd	NA	S.11001	NA	NA
+2701	Homes in Havering Ltd	NA	S.11001	NA	2012-10-01
+2702	Homes in Sedgemoor Ltd	NA	S.11001	NA	NA
+2704	Honorary Investment Advisory Committee	NA	S.1311	NA	1905-06-22
+2705	Honours Scrutiny Committee	NA	S.1311	NA	NA
+2707	Hope Cove Harbour Commissioners	NA	S.11001	NA	NA
+2708	Hopetoun Quay Ltd - (a BWB)	NA	S.11001	NA	NA
+2713	Horniman Museum	NA	S.1311	NA	NA
+2716	Horserace Betting Levy Appeals Tribunal for England and Wales	NA	S.1311	NA	NA
+2717	Horserace Betting Levy Appeals Tribunal for Scotland	NA	S.1311	NA	1905-06-24
+1299	NA	government-organisation:PB118	S.1311	NA	NA
+2718	Horserace Totaliser Board (HTB) (The Tote)	NA	S.11001	NA	NA
+1300	NA	local-authority-eng:HOR	S.1313	NA	NA
+2719	Horticultural Development Company Ltd	NA	S.1311	NA	NA
+1813	NA	government-organisation:OT902	S.1311	NA	NA
+2720	Horticulture Research International	NA	S.1311	NA	NA
+2728	Hounslow Homes Ltd	NA	S.11001	NA	NA
+1301	NA	government-organisation:IM341	S.1311	NA	NA
+2730	Houses of Parliament	NA	S.1311	NA	NA
+2732	Housing Action Trusts	NA	S.1311	NA	NA
+2733	Housing Benefit Review Boards	NA	S.1311	NA	NA
+2734	NA	government-organisation:EA835	S.1311	NA	NA
+2735	Housing for Wales	NA	S.1311	NA	NA
+2741	Housing Revenue Account	NA	S.11001	1990-04-01	NA
+2744	Hoy (Longhope) Aerodrome	NA	S.1313	NA	NA
+2745	HS1 Ltd	NA	S.11001	NA	2010-11-01
+2749	Hull Marina Ltd	NA	S.1313	NA	NA
+2750	Hull Resettlement Project	NA	S.1313	NA	NA
+1302	NA	government-organisation:PB253	S.1311	NA	NA
+2753	Human Genetics Commission	NA	S.1311	NA	NA
+1303	NA	government-organisation:PB254	S.1311	NA	NA
+2754	Humber Bridge Board	NA	S.11001	1998-04-01	NA
+2755	Humberside International Airport Ltd (s MA)	NA	S.11001	NA	2012-08-01
+2756	Humberside, Lincolnshire & North Yorkshire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1304	NA	local-authority-eng:HUN	S.1313	NA	NA
+2764	HW Poole and Son  Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+1305	NA	government-organisation:OT681	S.1311	2007-04-01	NA
+1847	NA	government-organisation:EA51	S.11001	NA	NA
+1306	NA	local-authority-eng:HYN	S.1313	NA	NA
+2769	Hywel Dda Health Board	NA	S.1311	2009-06-01	NA
+2770	IBS Viridian Ltd - (s BNFL)	NA	S.11001	NA	NA
+1307	NA	government-organisation:OT885	S.1311	NA	2013-05-01
+2772	Ilex Urban Regeneration Company Ltd	NA	S.1311	2003-07-01	NA
+2773	Ilfracombe Port	NA	S.1313	NA	NA
+2775	Immigration Appeal Tribunal	NA	S.1311	NA	NA
+2776	Immigration Appellate Authorities	NA	S.1311	NA	2005-04-01
+2777	Immigration Services Tribunal	NA	S.1311	NA	NA
+1308	NA	government-organisation:PB172	S.1311	NA	NA
+2779	Import Parity Price Panel	NA	S.1311	NA	NA
+2780	Improvement and Development Agency	NA	S.1313	NA	NA
+2784	Independent Advisory Group on Teenage Pregnancy	NA	S.1311	NA	2010-12-01
+1718	NA	government-organisation:IM335	S.1311	2011-05-01	NA
+2785	Independent Housing Ombudsman Limited	NA	S.1311	NA	NA
+1309	NA	government-organisation:PB349	S.1311	NA	NA
+2786	Independent Monitoring Board for the Military Corrective Training Centre (MCTC) Colchester	NA	S.1311	NA	NA
+2787	Independent Parliamentary Standards Authority	NA	S.1311	NA	NA
+1310	NA	government-organisation:PB456	S.1311	NA	NA
+2788	Independent Review Panel on the Classification of Borderline Medicines	NA	S.1311	NA	NA
+2789	Independent Review Services for Social Fund	NA	S.1311	NA	NA
+1311	NA	government-organisation:OT914	S.1311	NA	2012-12-01
+2790	Independent Scientific Group on Cattle TB (ISG)	NA	S.1311	NA	NA
+1312	NA	government-organisation:OT995	S.1311	NA	NA
+2791	Indian Family Pension Funds Body of Commissioners	NA	S.1311	NA	2001-05-01
+1313	NA	government-organisation:OT152	S.1311	NA	NA
+2792	Industrial Development Board for Northern Ireland	NA	S.1311	NA	NA
+1314	NA	government-organisation:PB231	S.1311	NA	NA
+2794	Industrial Research and Technology Unit (Advisory Board)	NA	S.1311	NA	NA
+2795	Industrial Training Boards	NA	S.1311	NA	NA
+2796	Industrial Tribunal Service	NA	S.1311	NA	NA
+2797	Industrial Tribunals (Northern Ireland)	NA	S.1311	NA	NA
+2798	Industry Department for Scotland	NA	S.1311	NA	NA
+1764	NA	government-organisation:PB298	S.1311	NA	NA
+2799	Information Tribunal	NA	S.1311	NA	NA
+2800	Inland Drainage Boards	NA	S.1313	NA	NA
+2801	Inland Revenue	NA	S.1311	NA	NA
+2802	Inland Waterways Advisory Council	NA	S.1311	NA	2012-07-01
+2803	Inland Waterways Amenity Advisory Council	NA	S.1311	NA	NA
+2806	Inshore Fisheries and Conservation Authorities (England)	NA	S.1313	2011-04-01	NA
+1315	NA	government-organisation:PB521	S.1311	NA	NA
+1316	NA	government-organisation:PB445	S.1311	NA	NA
+1882	NA	government-organisation:EA32	S.1311	NA	NA
+2807	Insolvency Service Investment Account	NA	S.1311	NA	NA
+2808	Institute for Animal Health	NA	S.1311	NA	2012-10-01
+2809	Institute of Animal Physiology	NA	S.1311	NA	NA
+2810	Institute of Hydrology	NA	S.1311	NA	NA
+2811	Institute of Oceanographic Sciences	NA	S.1311	NA	NA
+2812	Institute of Terrestrial Ecology	NA	S.1311	NA	NA
+2813	Institution for Further Education (IFE)	NA	S.11001	NA	2014-11-11
+2814	Institutions of Further Education (Northern Ireland)	NA	S.1311	1905-06-11	NA
+2815	Intack Services Limited	NA	S.11001	NA	NA
+2817	Integrated Transport Authorities	NA	S.1313	2009-02-01	NA
+2818	Intelligence Services Tribunal	NA	S.1311	NA	NA
+2819	Interception of Communications Tribunal	NA	S.1311	NA	NA
+2820	NA	register:internal-drainage-board	S.1313	NA	NA
+2821	International Nuclear Services Ltd - (s BNG / BNFL)	NA	S.11001	NA	NA
+2822	International Oil and Gas Business Advisory Board	NA	S.1311	NA	2002-04-01
+2823	International Rail Regulator (IRR)	NA	S.1311	NA	NA
+2824	InterTradeIreland	NA	S.1311	1999-12-01	NA
+2825	Intervention Board	NA	S.1311	NA	NA
+2826	Intervention Board for Agricultural Produce	NA	S.1311	NA	NA
+2827	Inventures	NA	S.11001	NA	NA
+2828	Inverary Port	NA	S.1313	NA	NA
+1883	NA	local-authority-sct:IVC	S.1313	NA	NA
+2829	Inverness Harbour	NA	S.11001	NA	2015-12-02
+2830	Invest Northern Ireland	NA	S.1311	NA	NA
+1317	NA	government-organisation:PB270	S.1311	NA	NA
+1765	NA	government-organisation:OT896	S.1311	NA	NA
+1318	NA	local-authority-eng:IPS	S.1313	NA	NA
+2831	Ipswich Buses Ltd	NA	S.11001	NA	NA
+2832	Irish Land Purchase Fund	NA	S.1311	NA	NA
+2834	Irvine Development Corporation	NA	S.11001	NA	NA
+1319	NA	principal-local-authority:AGY	S.1313	NA	NA
+2839	Isle of Skye Aerodrome	NA	S.1313	NA	NA
+1320	NA	local-authority-eng:IOW	S.1313	NA	NA
+2840	Islecare	NA	S.1313	NA	NA
+2844	Islwyn Borough Transport Ltd	NA	S.11001	NA	2010-01-01
+2846	Issue Department	NA	S.121	NA	NA
+2847	IT Services Ltd - (s BNFL)	NA	S.11001	NA	NA
+2848	ITSO Ltd	NA	S.11001	NA	2013-01-01
+2849	ITSO Services Ltd	NA	S.11001	NA	2013-01-01
+2858	Jobcentre Plus	NA	S.1311	2002-04-01	NA
+2866	Joint Air Reconnaissance Intelligence Centre	NA	S.1311	NA	NA
+2867	Joint Committee on Vaccination and Immunisation	NA	S.1311	NA	2012-07-01
+2868	Joint Fire and Rescue Boards (Scotland)	NA	S.1313	NA	2013-04-01
+1321	NA	government-organisation:PB201	S.1311	NA	NA
+2869	Joint Prison/Probation Accreditation Panel	NA	S.1311	NA	NA
+2874	Judge Advocate General	NA	S.1311	NA	NA
+2875	Judicial College	NA	S.1311	2011-04-01	NA
+1322	NA	government-organisation:OT1215	S.1311	1905-06-28	NA
+2876	Judicial Studies Board	NA	S.1311	NA	2011-04-01
+2878	Justices of the Peace Advisory Committees (Scotland)	NA	S.1311	NA	NA
+2879	Juvenile Justice Board	NA	S.1311	NA	NA
+2880	JV Network LLC [USA] (50%) (sBBCW) (Associate)	NA	S.11001	NA	NA
+2881	jv. JV Programmes LLC [USA] (50%) (sBBCW)	NA	S.11001	NA	NA
+2882	jv. UKTV1 - UK Channel Management Ltd (50%) (sBBCW)	NA	S.11001	NA	NA
+2883	jv. UKTV2 - UK Gold Holdings Ltd (50%) (sBBCW)	NA	S.11001	NA	NA
+2891	Kensington and Chelsea Tenant Management Organisation Ltd	NA	S.11001	NA	NA
+1323	NA	local-authority-eng:KEN	S.1313	NA	NA
+2892	Kent, Surrey & Sussex Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1324	NA	local-authority-eng:KET	S.1313	NA	NA
+2898	Kielder Property Management Ltd	NA	S.11001	NA	NA
+2908	King's Lynn and West Norfolk Borough Council	NA	S.1313	NA	NA
+2907	Kings College Hospital NHS Trust	NA	S.1311	NA	2006-12-01
+2911	Kingston upon Hull City Council	NA	S.1313	NA	NA
+2915	Kirklees Community Association	NA	S.1313	NA	NA
+2916	Kirklees Henry Boot Partnership Ltd	NA	S.1313	NA	NA
+2918	Kirklees Media Centre	NA	S.1313	NA	NA
+2919	Kirklees Metropolitan Borough Council	NA	S.1313	NA	NA
+2920	Kirklees Neighbourhood Housing Ltd	NA	S.11001	NA	NA
+2921	Kirklees Stadium Development Ltd	NA	S.1313	NA	NA
+2922	Kirklees Theatre Trust	NA	S.1313	NA	NA
+2923	Kirkwell Port	NA	S.1313	NA	NA
+2926	Know How Fund Advisory Board	NA	S.1311	NA	1905-06-21
+1325	NA	local-authority-eng:KWL	S.1313	NA	NA
+2931	KXC Landowners Limited	NA	S.11001	NA	NA
+2932	Laboratory Services Advisory Committee	NA	S.1311	NA	NA
+1326	NA	government-organisation:EA752	S.1311	NA	NA
+2933	Lace Hall Ltd, The	NA	S.1313	NA	NA
+2938	Laganside Corporation	NA	S.1311	NA	NA
+1327	NA	government-organisation:OT220	S.1313	1996-06-01	NA
+2940	Lambeth Living Ltd	NA	S.11001	NA	NA
+1328	NA	local-authority-eng:LAN	S.1313	NA	NA
+1329	NA	local-authority-eng:LAC	S.1313	NA	NA
+2944	Land and Property Services	NA	S.1311	NA	NA
+2945	Land Authority for Wales	NA	S.11001	NA	NA
+2946	Land Reform Advisory Committee for Northern Ireland	NA	S.1311	NA	NA
+1330	NA	government-organisation:EA700	S.1311	NA	NA
+1791	NA	government-organisation:PB358	S.1311	NA	NA
+2947	Land Registry, Her Majesty’s	NA	S.11001	NA	NA
+2948	Lands Tribunal	NA	S.1311	NA	NA
+2949	Lands Tribunal for Scotland	NA	S.1311	NA	NA
+2953	Langstone Harbour Board	NA	S.11001	NA	NA
+2954	Larch Cartons Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+2956	Larch Industries Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+2957	Larch Packaging Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+2958	Larch Plastics Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+1331	NA	government-organisation:PB294	S.1311	NA	NA
+2962	Law Reform Advisory Committee for Northern Ireland	NA	S.1311	NA	2007-03-31
+2964	LCR Finance plc	NA	S.1311	2009-06-01	NA
+2965	LCR Treasury Management Limited	NA	S.11001	NA	2011-09-01
+1332	NA	government-organisation:EA765	S.1311	NA	NA
+2966	Learning and Skills Development Agency	NA	S.11001	NA	NA
+2967	Learning and Skills Improvement Service (LSIS)	NA	S.1311	NA	2013-07-01
+2968	Learning and Teaching Scotland	NA	S.1311	NA	2011-04-01
+2969	Learning Trust (The)	NA	S.11001	NA	NA
+2970	LEASE Conferences Ltd	NA	S.11001	NA	NA
+1744	NA	government-organisation:PB373	S.1311	NA	NA
+2974	Lee Valley Regional Park Authority	NA	S.1313	1967-01-01	NA
+2975	Leed North East Homes Ltd	NA	S.11001	NA	NA
+2977	Leeds Bradford International Airport	NA	S.11001	NA	NA
+1333	NA	local-authority-eng:LDS	S.1313	NA	NA
+2978	Leeds East Homes Ltd	NA	S.11001	NA	NA
+2981	Leeds North West Homes Ltd	NA	S.11001	NA	NA
+2982	Leeds Port - (s BWB)	NA	S.11001	NA	NA
+2983	Leeds South East Homes Ltd	NA	S.11001	NA	NA
+2984	Leeds South Homes Ltd	NA	S.11001	NA	NA
+2985	Leeds West Homes Ltd	NA	S.11001	NA	NA
+2986	Legacy Trust UK Ltd	NA	S.1311	NA	NA
+1334	NA	government-organisation:EA556	S.1311	2013-04-01	NA
+1335	NA	government-organisation:OT994	S.1311	NA	NA
+2987	Legal Secretariat to the Law Officers, the	NA	S.1311	NA	NA
+1336	NA	government-organisation:IM332	S.1311	NA	NA
+1337	NA	government-organisation:PB300	S.1311	NA	2013-04-01
+2988	Legal Services Complaints Commissioner	NA	S.1311	NA	NA
+2989	Legal Services Consultative Panel	NA	S.1311	NA	NA
+2990	Legal Services Ombudsman	NA	S.1311	NA	NA
+1338	NA	local-authority-eng:LCE	S.1313	NA	NA
+1339	NA	local-authority-eng:LEC	S.1313	NA	NA
+2993	Leigh Port	NA	S.1313	NA	NA
+2996	Lerwick Harbour	NA	S.11001	NA	2015-12-02
+1340	NA	local-authority-eng:LEE	S.1313	NA	NA
+2999	Lewisham Homes Ltd	NA	S.11001	NA	NA
+3001	Library and Information Commission	NA	S.1311	NA	NA
+3002	Library and Information Services Council (Wales)	NA	S.1311	NA	NA
+1341	NA	local-authority-eng:LIF	S.1313	NA	NA
+3005	Life and other Annuities Warrant Account	NA	S.1311	NA	NA
+3007	Limehouse Developments Ltd (dormant) - (s BWB)	NA	S.11001	NA	NA
+1342	NA	local-authority-eng:LIN	S.1313	NA	NA
+3015	LINK/TCS Board	NA	S.1311	NA	NA
+3018	Lisburn and Castlereagh City Council	NA	S.1313	NA	NA
+3021	Littlehampton Harbour Board	NA	S.11001	NA	NA
+1343	NA	local-authority-eng:LIV	S.1313	NA	NA
+3022	Liverpool City Region Combined Authority	NA	S.1313	2014-04-01	NA
+1344	NA	government-organisation:OT849	S.1311	NA	NA
+3028	Living East (East of England Cultural Consortium)	NA	S.1311	NA	2010-09-01
+3029	Livingstone Development Corporation	NA	S.11001	NA	NA
+3031	Lloyds Bank (BLSA)	NA	S.12201	NA	2014-03-01
+3032	Lloyds Bank plc	NA	S.12201	NA	2014-03-01
+3033	Lloyds Bank Private Banking Limited	NA	S.12201	NA	2014-03-01
+3034	Lloyds Banking Group plc	NA	S.12301	NA	2014-03-01
+3035	Lloyds Banking Group plc subsidiaries	NA	S.11001	NA	NA
+3036	Local Authorities Departments (En Bloc)	NA	S.1313	NA	NA
+3037	Local Authority Airports	NA	S.11001	NA	NA
+3038	Local Authority Bus and Tram Companies	NA	S.11001	NA	NA
+1746	NA	government-organisation:OT916	S.1311	NA	2012-04-01
+3039	Local Enterprise Development Unit	NA	S.1311	NA	NA
+3040	Local Government Association	NA	S.1313	NA	NA
+3041	Local Government Association (Properties) Ltd	NA	S.1313	NA	NA
+3042	Local Government Boundary Commission for England	NA	S.1311	NA	NA
+3043	Local Government Boundary Commission for Scotland	NA	S.1311	NA	NA
+3044	Local Government Boundary Commission for Wales	NA	S.1311	NA	NA
+3045	Local Government Commission for England	NA	S.1311	NA	NA
+3046	Local Government Data Unit Wales	NA	S.1313	NA	NA
+3047	Local Government Information Unit	NA	S.1313	NA	NA
+3048	Local Government International Bureau	NA	S.1313	NA	NA
+3049	Local Government Pension Scheme	NA	S.12901	NA	NA
+3050	Local Government Property Commission (Scotland)	NA	S.1311	NA	NA
+3051	Local Government Residuary Body	NA	S.1311	NA	NA
+3052	Local Government Residuary Body, (England)	NA	S.1311	NA	NA
+3053	Local Government Staff Commission	NA	S.1311	NA	NA
+3054	Local Government Staff Commission (England)	NA	S.1311	NA	NA
+3055	Local Learning and Skills Councils	NA	S.1313	NA	NA
+3056	Local Partnerships LLP	NA	S.11001	2009-07-01	NA
+3058	Loch Lomond and the Trossachs National Park Authority	NA	S.1313	2002-07-01	NA
+3061	Lochmaddy Port	NA	S.1313	NA	NA
+3066	Logistic Information Systems Agency	NA	S.1311	NA	2001-04-01
+3067	London & Continental Railways (LCR) Limited	NA	S.11001	2013-09-01	NA
+3068	London & Continental Stations & Property Limited	NA	S.11001	NA	2008-12-01
+3070	London and Partners International Ltd	NA	S.1313	2011-04-01	NA
+3071	London and Partners Ltd	NA	S.1313	2011-04-01	NA
+3072	London Authorities Mutual Limited (The)	NA	S.12801	NA	NA
+1345	NA	local-authority-eng:BDG	S.1313	NA	NA
+1346	NA	local-authority-eng:BNE	S.1313	NA	NA
+1347	NA	local-authority-eng:BEX	S.1313	NA	NA
+1348	NA	local-authority-eng:BEN	S.1313	NA	NA
+1349	NA	local-authority-eng:BRY	S.1313	NA	NA
+1350	NA	local-authority-eng:CMD	S.1313	NA	NA
+1351	NA	local-authority-eng:CRY	S.1313	NA	NA
+1352	NA	local-authority-eng:EAL	S.1313	NA	NA
+1353	NA	local-authority-eng:ENF	S.1313	NA	NA
+1354	NA	local-authority-eng:HCK	S.1313	NA	NA
+1815	NA	local-authority-eng:HMF	S.1313	NA	NA
+1355	NA	local-authority-eng:HRY	S.1313	NA	NA
+1356	NA	local-authority-eng:HRW	S.1313	NA	NA
+1357	NA	local-authority-eng:HAV	S.1313	NA	NA
+1358	NA	local-authority-eng:HIL	S.1313	NA	NA
+1359	NA	local-authority-eng:HNS	S.1313	NA	NA
+1360	NA	local-authority-eng:ISL	S.1313	NA	NA
+1361	NA	local-authority-eng:LBH	S.1313	NA	NA
+1362	NA	local-authority-eng:LEW	S.1313	NA	NA
+1363	NA	local-authority-eng:MRT	S.1313	NA	NA
+1364	NA	local-authority-eng:NWM	S.1313	NA	NA
+1365	NA	local-authority-eng:RDB	S.1313	NA	NA
+1366	NA	local-authority-eng:RIC	S.1313	NA	NA
+1367	NA	local-authority-eng:SWK	S.1313	NA	NA
+1368	NA	local-authority-eng:STN	S.1313	NA	NA
+1369	NA	local-authority-eng:TWH	S.1313	NA	NA
+1370	NA	local-authority-eng:WFT	S.1313	NA	NA
+1371	NA	local-authority-eng:WND	S.1313	NA	NA
+3073	London Boroughs (En Bloc)	NA	S.1313	NA	NA
+3074	London Bus Services Ltd (s.TfL)	NA	S.11001	NA	NA
+3075	London Buses Ltd (s.TfL)	NA	S.1313	1905-06-22	NA
+3076	London Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+3078	London Development Agency	NA	S.1313	NA	2012-03-01
+3080	London Docklands Development Corporation - (LDDC)	NA	S.11001	NA	NA
+3081	London Fire and Emergency Planning Authority, The	NA	S.1313	NA	NA
+3083	London Legacy Development Corporation	NA	S.1313	2012-03-01	NA
+3084	London Luton Airport Ltd	NA	S.1313	1998-08-01	NA
+3085	London Olympic Bid Company / London 2012 Ltd	NA	S.1311	NA	2010-04-01
+3086	London Organising Committee of the Olympic Games (LOCOG)	NA	S.11001	NA	2013-06-01
+3087	London Pensions Fund Authority (operations)	NA	S.11001	NA	NA
+3088	London Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+3089	London Regional Transport	NA	S.11001	NA	NA
+3090	London River Services Ltd (s.TfL)	NA	S.11001	NA	NA
+1372	NA	government-organisation:PB374	S.1311	NA	2013-02-01
+3092	London Transport Museum (s.TfL)	NA	S.1313	1905-06-22	NA
+3093	London Transport Museum (Trading) Ltd	NA	S.11001	2008-04-01	NA
+3094	London Transport Users Committee (LTUC)	NA	S.1313	NA	NA
+3095	London Underground Ltd	NA	S.11001	NA	NA
+3096	London Waste and Recycling Board	NA	S.1313	NA	NA
+3097	Londonderry Port and Harbour Commissioners	NA	S.11001	NA	NA
+1373	NA	government-organisation:D595	S.1311	NA	2005-06-01
+3103	Lord Chancellor's Legal Aid Advisory Committee (Northern Ireland)	NA	S.1311	NA	2006-03-01
+3104	Lord Chief Justice, The	NA	S.1311	NA	NA
+3108	Lothian Buses plc	NA	S.11001	NA	NA
+1374	NA	government-organisation:OT862	S.1311	1999-12-01	NA
+3111	Low Carbon Contracts Company	NA	S.1311	2014-08-01	NA
+3112	Low Level Waste Repository (LLWR) Ltd	NA	S.1311	2008-04-01	NA
+1375	NA	government-organisation:PB122	S.1311	NA	NA
+3114	LUL Nominee BCV Ltd	NA	S.1313	2008-05-01	NA
+3115	LUL Nominee SSL Ltd	NA	S.1313	2008-05-01	NA
+1376	NA	local-authority-eng:LUT	S.1313	NA	NA
+3120	Luton International Airport Ltd	NA	S.11001	NA	1998-08-01
+3123	Lyme Regis Port	NA	S.1313	NA	NA
+3127	Macaulay Land Use Research Institute	NA	S.1311	NA	2011-04-01
+3128	Macaulay Research and Consultancy Services Ltd	NA	S.11001	NA	NA
+3129	Macduff Port	NA	S.1313	NA	NA
+3130	MacFarlane Trust	NA	S.1311	NA	NA
+3131	Magistrates Courts (En Bloc)	NA	S.1311	2005-04-01	NA
+3132	Magistrates Courts Rule Committee	NA	S.1311	NA	2012-09-01
+3133	Magistrates Courts Rules Committee (Northern Ireland)	NA	S.1311	1905-06-03	NA
+3138	Magnox Electric Ltd (s BNFL)	NA	S.1311	NA	2008-10-01
+3139	Magnox Electric plc	NA	S.11001	NA	2005-04-01
+3140	Magnox Limited	NA	S.1311	2011-01-01	NA
+3141	Magnox North Ltd. (s. BNFL)	NA	S.1311	NA	2011-01-01
+3142	Magnox South Ltd. (s. BNFL)	NA	S.1311	NA	2011-01-01
+1377	NA	local-authority-eng:MAI	S.1313	NA	NA
+1378	NA	local-authority-eng:MAL	S.1313	NA	NA
+3146	Mallaig Harbour	NA	S.11001	NA	2015-12-02
+1379	NA	local-authority-eng:MAV	S.1313	NA	NA
+3147	Manchester (Barton) Aerodrome	NA	S.1313	NA	NA
+3148	Manchester Airport Building Ltd (s MA)	NA	S.11001	NA	2006-07-01
+3149	Manchester Airport Employment Services Ltd (s MA)	NA	S.11001	NA	2006-07-01
+3150	Manchester Airport Finance Holdings Ltd	NA	S.11001/3	2013-02-01	NA
+3151	Manchester Airport Finance Ltd (s MA)	NA	S.11001	NA	2006-07-01
+3152	Manchester Airport Group Finance Ltd	NA	S.11001/3	2013-02-01	NA
+3153	Manchester Airport Group plc	NA	S.11001/3	2013-02-01	NA
+3154	Manchester Airport Group Property Developments Ltd	NA	S.11001/3	2013-02-01	NA
+3155	Manchester Airport Group Property Services Ltd	NA	S.11001/3	2013-02-01	NA
+3156	Manchester Airport Holdings Limited	NA	S.12701/03	2013-02-01	NA
+3157	Manchester Airport plc	NA	S.11001/3	2013-02-01	NA
+1380	NA	local-authority-eng:MAN	S.1313	NA	NA
+3159	Manchester Investment and Development Agency Service Ltd	NA	S.1313	NA	NA
+1381	NA	local-authority-eng:MAS	S.1313	NA	NA
+3166	Mansfields (Norwich) Ltd - (s Remploy Ltd )	NA	S.11001	NA	NA
+3167	Mansfields Group Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+3171	Marine and Aviation (War Risks) Fund	NA	S.1311	NA	NA
+1850	NA	government-organisation:EA843	S.1311	NA	NA
+1382	NA	government-organisation:PB57	S.1311	NA	NA
+3172	Marine Safety Agency	NA	S.1311	NA	NA
+3173	Marine Scotland	NA	S.1311	2009-04-01	NA
+1383	NA	government-organisation:EA78	S.1311	NA	NA
+1384	NA	government-organisation:OT315	S.1311	NA	NA
+3183	Master of the Rolls	NA	S.1311	NA	NA
+3186	Mayor's Office for Policing and Crime	NA	S.1313	2012-01-01	NA
+3187	Maze / Long Kesh Development Corporation	NA	S.1311	2012-09-01	NA
+3188	Measurement Advisory Committee	NA	S.1311	NA	NA
+1742	NA	government-organisation:OT876	S.1311	NA	NA
+3189	Meat Hygiene Advisory Committee	NA	S.1311	NA	2004-09-01
+3190	Meat Hygiene Appeals Tribunal for England and Wales	NA	S.1311	NA	NA
+1385	NA	government-organisation:EA873	S.1311	NA	2010-04-01
+3191	Medical Appeal Tribunals Northern Ireland	NA	S.1311	NA	NA
+3192	Medical Appeals Tribunal	NA	S.1311	NA	NA
+3193	Medical Devices Agency	NA	S.1311	NA	NA
+3194	Medical Practices Committee	NA	S.1311	NA	NA
+1386	NA	government-organisation:PB132	S.1311	NA	NA
+3195	Medical Research Council Technology	NA	S.11001	2010-04-01	NA
+1387	NA	government-organisation:EA705	S.1311	NA	2005-03-01
+3196	Medical Workforce Standing Advisory Committee	NA	S.1311	NA	1905-06-25
+1388	NA	government-organisation:EA63	S.11001	NA	NA
+3197	Medicines Commission	NA	S.1311	NA	NA
+1389	NA	local-authority-eng:MDW	S.1313	NA	NA
+1390	NA	local-authority-eng:MEL	S.1313	NA	NA
+1391	NA	local-authority-eng:MEN	S.1313	NA	NA
+1392	NA	government-organisation:OT800	S.1311	NA	2009-03-01
+3200	Mental Health Commission for Northern Ireland	NA	S.1311	NA	2009-04-01
+3201	Mental Health Review Tribunal	NA	S.1311	NA	NA
+3202	Mental Health Review Tribunal for Northern Ireland	NA	S.1311	NA	NA
+3203	Mental Health Review Tribunal for Wales	NA	S.1311	NA	NA
+3204	Mental Welfare Commission for Scotland	NA	S.1311	NA	NA
+3205	Merchant Navy Reserve	NA	S.1311	NA	NA
+3212	Merseyside and North Wales Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+3213	Merseyside Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+3214	Merseyside Development Corporation	NA	S.11001	NA	NA
+3215	Merseyside Passenger Transport Executive - (s PTE)	NA	S.1313	1998-04-01	NA
+3216	Merseyside Waste Authority	NA	S.1313	1986-01-01	NA
+3217	Merseytravel - (Merseyside Passenger Transport Executive)	NA	S.11001	NA	NA
+1393	NA	principal-local-authority:MTY	S.1313	NA	NA
+3221	Meteorological Office	NA	S.11001	NA	NA
+3223	Metronet Rail BCV Holdings Ltd	NA	S.11001	NA	1905-07-03
+3224	Metronet Rail SSL Holdings Ltd	NA	S.11001	NA	1905-07-03
+3227	Metropolitan Police Authority	NA	S.1313	NA	2012-01-01
+3228	Metropolitan Police Committee	NA	S.1311	NA	2000-01-01
+3229	Microbiological Research Authority	NA	S.1311	NA	NA
+3230	Mid and East Antrim Borough Council	NA	S.1313	NA	NA
+1394	NA	local-authority-eng:MDE	S.1313	NA	NA
+1395	NA	local-authority-eng:MSU	S.1313	NA	NA
+1396	NA	local-authority-eng:MSS	S.1313	NA	NA
+3231	Mid Ulster District Council	NA	S.1313	NA	NA
+3232	Middle Level Commissioners	NA	S.1313	NA	NA
+3233	Middlesbrough Council	NA	S.1313	NA	NA
+3235	Midlands Region Electricity Consumers Committee	NA	S.1311	NA	NA
+1884	NA	local-authority-sct:MLN	S.1313	NA	NA
+3238	Milford Haven Port Authority	NA	S.11001	NA	NA
+3239	Military Survey	NA	S.1311	NA	NA
+1753	NA	government-organisation:OT851	S.1311	NA	NA
+1397	NA	government-organisation:OT719	S.1311	NA	NA
+3245	Milton Keynes - (s NTC)	NA	S.1311	NA	NA
+1398	NA	local-authority-eng:MIK	S.1313	NA	NA
+3246	Minehead Port	NA	S.1313	NA	NA
+3247	Mineworker's Pension Scheme	NA	S.12901	1994-10-31	NA
+1399	NA	government-organisation:D17	S.1311	NA	NA
+1808	NA	government-organisation:EA693	S.1311	NA	2012-04-01
+1400	NA	government-organisation:D18	S.1311	NA	NA
+3251	Misuse of Drugs Advisory Board	NA	S.1311	NA	NA
+3252	Misuse of Drugs Professional Panel	NA	S.1311	NA	NA
+3253	Misuse of Drugs Tribunal	NA	S.1311	NA	NA
+3255	MNE Ltd.	NA	S.11001	NA	NA
+1401	NA	local-authority-eng:MOL	S.1313	NA	NA
+3262	Money Advice Service	NA	S.1311	2011-04-01	NA
+3263	Monitor – Independent Regulator of NHS Foundation Trusts	NA	S.1311	NA	NA
+1402	NA	principal-local-authority:MON	S.1313	NA	NA
+1403	NA	government-organisation:OT592	S.1311	NA	NA
+3266	Montrose Port	NA	S.11001	NA	2015-12-02
+3268	Moray Council	NA	S.1313	NA	NA
+3269	Moredun Research Institute	NA	S.1311	NA	NA
+3270	Mortgage Express	NA	S.12201	NA	NA
+3280	Multimedia Ventures Ltd (50%) (sWS) (Associate)	NA	S.11001	NA	2013-06-13
+3284	Museum of Kent Life Trust	NA	S.1313	NA	NA
+3285	Museum of London	NA	S.1313	NA	NA
+3286	Museum of Science and Industry in Manchester	NA	S.1311	NA	2012-01-01
+3287	Museums and Galleries Commission	NA	S.1311	NA	NA
+1785	NA	government-organisation:OT936	S.1311	NA	2012-05-01
+3288	Musselburgh Port	NA	S.1313	NA	NA
+3290	N.I.R Leasing Limited - (s NITHC)	NA	S.11001	NA	NA
+3291	N.I.R Travel Limited - (s NITHC)	NA	S.11001	NA	NA
+3294	Nairn Port	NA	S.1313	NA	NA
+3295	National Advisory Council for the Employment of People with Disabilities	NA	S.1311	NA	NA
+3296	National Air Traffic Services Ltd - (s CAA)	NA	S.11001	NA	NA
+1887	NA	government-organisation:EA71	S.1311	NA	NA
+3297	National Archives of Scotland	NA	S.1311	NA	2011-04-01
+1404	NA	government-organisation:PB307	S.1311	NA	NA
+3298	National Assembly for Wales	NA	S.1311	NA	NA
+3299	National Association of Citizens Advice Bureau (England and Wales) (The)	NA	S.1311	NA	2013-11-01
+3300	National Audit Office	NA	S.1311	NA	NA
+1726	NA	government-organisation:EA656	S.1311	NA	2009-04-01
+1405	NA	government-organisation:OT774	S.11001	NA	NA
+3301	National Board for Nursing, Midwifery and Health Visiting for Northern Ireland	NA	S.1311	NA	2002-04-01
+3302	National Board for Nursing, Midwifery and Health Visiting for Scotland	NA	S.1311	NA	2002-04-01
+1406	NA	government-organisation:OT629	S.1311	NA	NA
+3303	National Clinical Assessment Authority (NCAA)	NA	S.1311	NA	2005-04-01
+1407	NA	government-organisation:EA929	S.1311	NA	2013-04-01
+1408	NA	government-organisation:EA541	S.1311	2013-04-01	NA
+3304	National Consumer Council	NA	S.1311	NA	2008-04-01
+3305	National Consumers Consultative Committee (Electricity) (NCCC)	NA	S.1311	NA	NA
+3306	National Council for Education and Training for Wales	NA	S.1311	NA	NA
+1409	NA	government-organisation:PB558	S.1311	2013-10-01	NA
+1410	NA	government-organisation:OT703	S.1311	NA	2006-04-01
+1411	NA	government-organisation:EA704	S.1311	NA	2006-04-01
+3308	National Curriculum Council	NA	S.1311	NA	NA
+3309	National Disability Council	NA	S.1311	NA	NA
+1412	NA	government-organisation:PB399	S.1311	NA	NA
+3310	National Employment Panel	NA	S.1311	NA	NA
+3311	National Employment Savings Trust Corporation (NEST)	NA	S.12901	NA	NA
+1806	NA	government-organisation:OT658	S.1311	NA	2012-04-01
+3312	National Exhibition Centre Limited	NA	S.1313	NA	2015-05-01
+3313	National Expert Group on Transboundary Air Pollution	NA	S.1311	NA	NA
+1413	NA	government-organisation:PB415	S.1311	NA	NA
+1414	NA	government-organisation:PB29	S.1311	2008-10-01	NA
+3314	National Fuel Distributors Ltd - (s HI)	NA	S.11001	NA	NA
+3315	National Galleries of Scotland	NA	S.1311	NA	NA
+1415	NA	government-organisation:PB174	S.1311	NA	NA
+3316	National Health Service Business Services Authority	NA	S.1311	NA	NA
+3317	National Health Service Central Register	NA	S.1311	NA	NA
+3318	National Health Service Commissioning Board, The	NA	S.1311	2012-10-01	NA
+3319	National Health Service Estates	NA	S.11001	NA	NA
+3320	National Health Service Foundation Trusts (England)	NA	S.1311	NA	NA
+3321	National Health Service Information Authority	NA	S.1311	NA	2005-04-01
+3322	National Health Service Litigation Authority	NA	S.1311	NA	NA
+3323	National Health Service Pensions Agency	NA	S.1311	NA	NA
+3324	National Health Service Professionals South West	NA	S.1311	NA	NA
+3325	National Health Service Supplies Authority	NA	S.1311	NA	NA
+3326	National Health Service Training Authority	NA	S.1311	NA	NA
+3327	National Health Service Tribunal	NA	S.1311	NA	NA
+3328	National Health Service Trusts (England)	NA	S.1311	NA	NA
+3329	National Health Service Trusts (Wales)	NA	S.1311	1905-06-28	NA
+1416	NA	government-organisation:PB175	S.1311	NA	NA
+3330	National Heritage Memorial Fund Investment Account	NA	S.1311	NA	NA
+3331	National Institute for Clinical Excellence (The)	NA	S.1311	NA	2005-04-01
+3332	National Institute for Health and Clinical Excellence (The)	NA	S.1311	NA	2005-04-01
+1796	NA	government-organisation:PB474	S.1311	2013-04-01	NA
+3333	National Insurance Contributions Office	NA	S.1311	NA	NA
+3334	National Insurance Fund	NA	S.1311	NA	NA
+3335	National Insurance Local Tribunals	NA	S.1311	NA	NA
+3336	National Investment and Loans Office	NA	S.1311	NA	NA
+3337	National Library of Scotland	NA	S.1311	NA	NA
+3338	National Library of Wales	NA	S.1311	NA	NA
+3339	National Library of Wales Staff Superannuation Scheme	NA	S.12901	2007-03-13	NA
+3340	National Loans Fund	NA	S.1311	NA	NA
+3341	National Lottery Commission	NA	S.1311	NA	NA
+3342	National Lottery Distribution Fund	NA	S.1311	NA	NA
+3343	National Lottery UK Sports Council Lottery	NA	S.1311	NA	NA
+3344	National Maritime Museum	NA	S.1311	NA	NA
+1738	NA	government-organisation:EA33	S.1311	NA	NA
+1417	NA	government-organisation:PB290	S.1311	NA	NA
+3345	National Museum of Wales Pension Scheme	NA	S.12901	2006-06-21	NA
+1418	NA	government-organisation:OT868	S.1311	NA	NA
+3346	National Museums and Galleries of Wales	NA	S.1311	NA	NA
+3347	National Museums and Galleries on Merseyside	NA	S.1311	NA	NA
+1419	NA	government-organisation:PB178	S.1311	NA	NA
+1420	NA	government-organisation:OT987	S.1311	NA	NA
+3348	National Non Food Crop Centre	NA	S.1311	NA	2012-10-01
+3349	National Nuclear Laboratories Ltd	NA	S.11001	2009-04-01	NA
+3350	National Parks Authorities (En Bloc)	NA	S.1313	NA	NA
+1421	NA	government-organisation:EA860	S.1311	NA	2012-10-01
+1422	NA	government-organisation:EA904	S.1311	NA	2013-10-01
+1423	NA	government-organisation:PB179	S.1311	NA	NA
+1772	NA	government-organisation:OT723	S.1311	NA	NA
+1424	NA	government-organisation:OT730	S.1311	NA	2005-04-01
+1425	NA	government-organisation:OT1075	S.1311	2011-04-01	NA
+3351	National Research Development Corporation	NA	S.1311	NA	NA
+3352	National Savings Bank (Ordinary and Investment accounts)	NA	S.1311	NA	NA
+3353	National Savings Stock Register Cash Account	NA	S.1311	NA	NA
+1426	NA	government-organisation:OT891	S.1311	NA	2012-03-01
+3354	National Specialist Commissioning Advisory Group	NA	S.1311	NA	NA
+3355	National Stone Centre	NA	S.1313	NA	NA
+1773	NA	government-organisation:EA692	S.1311	NA	2013-04-01
+3356	National Waiting Times Centre Board	NA	S.1311	2002-06-01	NA
+1817	NA	government-organisation:OT712	S.1311	NA	NA
+3357	National Westminster Bank plc	NA	S.12201	NA	NA
+3358	National Youth Agency	NA	S.1311	NA	NA
+1427	NA	government-organisation:PB202	S.1311	NA	NA
+1723	NA	government-organisation:PB133	S.1311	NA	NA
+1428	NA	government-organisation:PB180	S.1311	NA	NA
+1429	NA	government-organisation:OT1103	S.1311	2013-04-01	NA
+3359	Naval Aircraft Repair Organisation	NA	S.1311	NA	NA
+3360	Naval Bases and Supply Agency	NA	S.1311	NA	NA
+3361	Naval Manning Agency	NA	S.1311	NA	2004-04-01
+3362	Naval Recruiting and Training Agency	NA	S.1311	NA	2006-04-01
+3363	Navy, Army and Air Force Institute	NA	S.11001	NA	NA
+3364	NDA Archives Limited	NA	S.1311	2014-07-01	NA
+1430	NA	principal-local-authority:NTL	S.1313	NA	NA
+3366	NESTA Endowment Account (National Endowment for Science Technology and Arts)	NA	S.1311	NA	NA
+3367	NESTA Trust, The	NA	S.1311	2011-07-01	NA
+3370	Network Rail Limited	NA	S.1311	2004-04-01	NA
+3376	New Deal Task  Force	NA	S.1311	NA	2001-10-01
+1431	NA	local-authority-eng:NEW	S.1313	NA	NA
+1432	NA	government-organisation:OT222	S.1313	2005-04-01	NA
+3383	New Millennium Experience Company Ltd	NA	S.11001	NA	NA
+1433	NA	government-organisation:OT852	S.1311	NA	NA
+3390	New Video Channel America LLC [USA] (s BBCW)	NA	S.11001	NA	NA
+1434	NA	local-authority-eng:NEA	S.1313	NA	NA
+3393	Newark and Sherwood Homes Ltd	NA	S.11001	NA	NA
+3396	Newcastle International Airport Ltd	NA	S.11001	NA	NA
+1435	NA	local-authority-eng:NEC	S.1313	NA	NA
+3397	Newcastle-upon-Tyne City Council	NA	S.1313	NA	NA
+3398	Newcastle-upon-Tyne MDC	NA	S.1313	NA	NA
+3399	Newham Homes Ltd	NA	S.11001	NA	2011-04-01
+3403	Newlyn Pier and Harbour Commissioners	NA	S.11001	NA	NA
+3404	Newport (IOW) Port	NA	S.1313	NA	NA
+1436	NA	principal-local-authority:NWP	S.1313	NA	NA
+3406	Newport Transport Ltd	NA	S.11001	NA	NA
+3407	Newquay Port	NA	S.1313	NA	NA
+3408	Newry, Mourne and Down District Council	NA	S.1313	NA	NA
+3410	Nexia Solutions Ltd. (s. BNFL)	NA	S.11001	NA	NA
+3412	Nexus (Tyne and Wear Passenger Transport Executive)	NA	S.1313	NA	NA
+3413	NFPA Scotland Ltd	NA	S.11001	2005-07-01	NA
+3414	NHS 24	NA	S.1311	NA	NA
+1437	NA	government-organisation:OT486	S.11001	NA	NA
+3415	NHS Board Endowment Funds (Scotland) - aka Scottish NHS Charities	NA	S.1311	1905-05-25	NA
+1792	NA	government-organisation:OT529	S.1311	NA	NA
+3416	NHS Charities in England and Wales (En Bloc)	NA	S.1311	NA	NA
+3417	NHS Commissioning Board Special Health Authority	NA	S.1311	NA	2012-10-01
+3418	NHS Confederation, The	NA	S.1311	NA	NA
+3419	NHS Direct NHS Trust (England)	NA	S.1311	2007-04-01	NA
+3420	NHS Education for Scotland	NA	S.1311	2002-03-01	NA
+1438	NA	government-organisation:OT709	S.11001	NA	NA
+3421	NHS Health Scotland Board	NA	S.1311	2003-04-01	NA
+1439	NA	government-organisation:OT803	S.1311	NA	NA
+1440	NA	government-organisation:OT804	S.11001	NA	NA
+1441	NA	government-organisation:EA633	S.1311	2006-04-01	NA
+1442	NA	government-organisation:OT805	S.1311	NA	NA
+3422	NHS Professionals Limited	NA	S.11001	2010-04-01	NA
+3423	NHS Professionals South West	NA	S.1311	NA	NA
+1443	NA	government-organisation:EA716	S.1311	NA	2010-03-01
+3424	NHS Quality Improvement Scotland	NA	S.1311	NA	2011-04-01
+1444	NA	government-organisation:OT484	S.1311	2012-06-01	NA
+3425	NHS Trusts (England) (En Bloc)	NA	S.1311	NA	NA
+3428	Non Fossil Purchasing Agency Ltd	NA	S.11001	2000-10-01	NA
+3429	Norden Farm Centre Trust	NA	S.1313	NA	NA
+3430	Norfolk & Suffolk Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1445	NA	local-authority-eng:NFK	S.1313	NA	NA
+1854	NA	local-authority-sct:NAY	S.1313	NA	NA
+3431	North Ayrshire Municipal Bank Ltd	NA	S.12501	NA	NA
+3433	North Berwick Harbour	NA	S.11001	NA	2015-12-02
+3435	North Connel (Oban) Aerodrome	NA	S.1313	NA	NA
+3436	North Devon Council	NA	S.1313	NA	NA
+3437	North Devon Homes Limited	NA	S.11001	NA	NA
+1446	NA	local-authority-eng:NDO	S.1313	NA	NA
+1447	NA	local-authority-eng:NED	S.1313	NA	NA
+1448	NA	local-authority-eng:NEL	S.1313	NA	NA
+3439	North East of Scotland Transport Partnership (NESTRANS)	NA	S.1313	2005-12-01	NA
+3440	North East Wales Careers Service Ltd	NA	S.1311	2013-04-01	NA
+1810	NA	government-organisation:OT781	S.1311	NA	NA
+3441	North Eastern Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+1449	NA	local-authority-eng:NHE	S.1313	NA	NA
+3445	North Hull Housing Action Trust	NA	S.1311	NA	NA
+3446	North Kent Architecture Centre Ltd	NA	S.1313	NA	NA
+1450	NA	local-authority-eng:NKE	S.1313	NA	NA
+1839	NA	local-authority-sct:NLK	S.1313	NA	NA
+3447	North Lanarkshire Municipal Bank Ltd	NA	S.12501	NA	NA
+1451	NA	local-authority-eng:NLN	S.1313	NA	NA
+3449	North London Waste Authority	NA	S.1313	1986-01-01	NA
+1452	NA	local-authority-eng:NNO	S.1313	NA	NA
+3451	North of Scotland Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+3452	North of Scotland Water Authority	NA	S.11001	NA	NA
+3453	North Ronaldsay Aerodrome	NA	S.1313	NA	NA
+1453	NA	local-authority-eng:NSM	S.1313	NA	NA
+3454	North South Language Body (An Foras Teanga North-South Body o Leid) (The)	NA	S.1311	1999-12-01	NA
+1454	NA	local-authority-eng:NTY	S.1313	NA	NA
+1455	NA	local-authority-eng:NWA	S.1313	NA	NA
+3458	North West Cultural Consortium	NA	S.1311	NA	2010-09-01
+1456	NA	local-authority-eng:NWL	S.1313	NA	NA
+1788	NA	government-organisation:EA920	S.1311	NA	2012-07-01
+3459	North Western Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+1457	NA	local-authority-eng:NYK	S.1313	NA	NA
+1824	NA	government-organisation:OT223	S.1313	1996-06-01	NA
+1458	NA	local-authority-eng:NOR	S.1313	NA	NA
+1459	NA	local-authority-eng:NTH	S.1313	NA	NA
+1857	NA	government-organisation:OT863	S.1311	NA	NA
+3463	Northern Health and Social Care Trust	NA	S.1311	2010-04-01	NA
+3464	Northern Housing Consortium (NHC)	NA	S.1313	NA	NA
+3465	Northern Ireland Advisory Committee on Telecommunications	NA	S.1311	NA	NA
+3466	Northern Ireland Advisory Committee on Travellers	NA	S.1311	NA	NA
+3467	Northern Ireland Airports Ltd	NA	S.11001	NA	1905-06-16
+3468	Northern Ireland Ambulance Service Health and Social Care Trust, The	NA	S.1311	2010-04-01	NA
+3469	Northern Ireland Assembly Commission	NA	S.1311	NA	NA
+1460	NA	government-organisation:OT634	S.1311	1987-04-01	NA
+1461	NA	government-organisation:OT761	S.1311	NA	NA
+3470	Northern Ireland Blood Transfusion Service Agency	NA	S.1311	NA	NA
+3471	Northern Ireland Building Regulations Advisory Committee	NA	S.1311	NA	NA
+3472	Northern Ireland Central Investment Fund for Charities	NA	S.12601	NA	NA
+3473	Northern Ireland Central Services Agency (NICSA)	NA	S.1311	NA	2009-04-01
+1462	NA	government-organisation:EA810	S.1311	NA	2008-04-01
+3474	Northern Ireland Commissioner for Protection Against Unlawful Industrial Action	NA	S.1311	NA	NA
+3475	Northern Ireland Commissioner for the Rights of Trade Union Members	NA	S.1311	NA	NA
+3476	Northern Ireland Community Relations Council	NA	S.1311	1905-06-12	NA
+3477	Northern Ireland Consolidated Fund	NA	S.1311	NA	NA
+3478	Northern Ireland Consumer Committee for Electricity	NA	S.1311	NA	NA
+3479	Northern Ireland Cooperation Overseas (NI-CO) Ltd	NA	S.11001	2009-12-01	NA
+3480	Northern Ireland Council for Postgraduate Medical and Dental Education	NA	S.1311	NA	NA
+1826	NA	government-organisation:OT644	S.1311	NA	NA
+3481	Northern Ireland Courts and Tribunals Service	NA	S.1311	2010-04-01	NA
+1793	NA	government-organisation:EA725	S.1311	NA	2010-04-01
+3482	Northern Ireland Crown Court Rules Committee	NA	S.1311	1905-05-31	NA
+3483	Northern Ireland Disability Council	NA	S.1311	NA	NA
+3484	Northern Ireland District Councils (En Bloc)	NA	S.1313	NA	NA
+3485	Northern Ireland Driver Vehicle Testing Agency	NA	S.11001	NA	NA
+3486	Northern Ireland Economic Council	NA	S.1311	NA	NA
+3487	Northern Ireland Economic Development Council	NA	S.1311	NA	NA
+3488	Northern Ireland Education and Library Boards	NA	S.1311	NA	NA
+3489	Northern Ireland Environment Agency	NA	S.1311	2008-07-01	NA
+3490	Northern Ireland Fire and Rescue Board	NA	S.1311	2006-07-01	NA
+3491	Northern Ireland Fishery Harbour Authority	NA	S.1311	NA	NA
+3492	Northern Ireland Government Departments (En Bloc)	NA	S.1311	NA	NA
+3493	Northern Ireland Guardian Ad Litem Agency (NIGALA)	NA	S.1311	NA	NA
+3494	Northern Ireland Health and Social Care Trust Charitable Funds	NA	S.1311	NA	NA
+3495	Northern Ireland Health Promotion Agency	NA	S.1311	NA	2009-04-01
+3496	Northern Ireland Higher Education Council	NA	S.1311	NA	NA
+1735	NA	government-organisation:PB1212	S.11001	NA	NA
+1463	NA	government-organisation:OT429	S.1311	NA	NA
+3497	Northern Ireland Industrial Court	NA	S.1311	NA	NA
+3498	Northern Ireland Industrial Tribunals	NA	S.1311	NA	NA
+1464	NA	government-organisation:OT880	S.1311	2005-06-01	NA
+1465	NA	government-organisation:OT937	S.1311	2007-04-01	NA
+1466	NA	government-organisation:OT783	S.1311	2003-11-01	NA
+3499	Northern Ireland Library Authority	NA	S.1311	NA	NA
+1775	NA	government-organisation:OT758	S.1311	NA	NA
+3500	Northern Ireland Medical and Dental Training Agency	NA	S.1311	NA	NA
+3501	Northern Ireland Memorial Fund	NA	S.1311	NA	2013-04-01
+3502	Northern Ireland Museums Council	NA	S.1311	NA	NA
+1467	NA	government-organisation:D19	S.1311	NA	NA
+1468	NA	government-organisation:OT828	S.1311	NA	NA
+1469	NA	government-organisation:OT935	S.1311	NA	NA
+1470	NA	government-organisation:OT649	S.1311	NA	NA
+3503	Northern Ireland Postal Services Committee	NA	S.1311	NA	2008-04-01
+1471	NA	government-organisation:EA797	S.1311	NA	NA
+3504	Northern Ireland Public Sector Enterprise	NA	S.11001	NA	2009-12-01
+3505	Northern Ireland Railways Company Ltd - (s NITHC)	NA	S.11001	NA	NA
+3506	Northern Ireland Regional Medical Physics Agency (NIRMPA)	NA	S.1311	NA	NA
+3507	Northern Ireland Review Body (Driver, Operator and Vehicle Licensing)	NA	S.1311	NA	NA
+3508	Northern Ireland Rural Development Council	NA	S.1311	NA	NA
+3509	Northern Ireland Schools (En Bloc)	NA	S.1311	NA	NA
+3510	Northern Ireland Screen Commission	NA	S.1311	NA	NA
+1739	NA	government-organisation:OT770	S.1311	2001-10-01	NA
+1472	NA	government-organisation:EA701	S.1311	NA	NA
+3511	Northern Ireland Strategic Investment Board Ltd	NA	S.1311	NA	NA
+1473	NA	government-organisation:OT820	S.1311	NA	NA
+3512	Northern Ireland Transport Holding Company (NITHC)	NA	S.11001	NA	NA
+3513	Northern Ireland Utility Regulator	NA	S.1311	NA	NA
+3514	Northern Ireland Water Council	NA	S.1311	NA	NA
+3515	Northern Ireland Water Limited	NA	S.1311	NA	NA
+3516	Northern Ireland Water Service	NA	S.1311	NA	NA
+1474	NA	government-organisation:PB463	S.1311	1905-04-29	NA
+3517	Northern Rock Asset Management plc	NA	S.1311	2010-01-01	NA
+3518	Northern Rock Estates Ltd.	NA	S.11001	NA	NA
+3519	Northern Rock Homes Ltd.	NA	S.11001	NA	NA
+3520	Northern Rock plc	NA	S.11001	NA	2012-01-01
+3521	Northern Rock Properties Ltd.	NA	S.11001	NA	NA
+3522	Northern Rock Traffic Management Ltd.	NA	S.11001	NA	NA
+3523	Northlink Ferries Ltd	NA	S.1311	2006-07-01	NA
+1475	NA	local-authority-eng:NBL	S.1313	NA	NA
+1476	NA	government-organisation:OT543	S.1313	1996-06-01	NA
+3524	Northumbria Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+3525	Northwards Housing Ltd	NA	S.11001	NA	NA
+3527	Norwich Airport Ltd	NA	S.11001	NA	NA
+1477	NA	local-authority-eng:NOW	S.1313	NA	NA
+3530	Norwich Port	NA	S.1313	NA	NA
+1478	NA	local-authority-eng:NGM	S.1313	NA	NA
+3534	Nottingham City Homes Ltd	NA	S.11001	NA	NA
+3535	Nottingham City Transport Co Ltd	NA	S.11001	NA	NA
+1479	NA	local-authority-eng:NTT	S.1313	NA	NA
+3539	NPL Management Limited	NA	S.11001	2015-01-01	NA
+1480	NA	government-organisation:EA104	S.1311	NA	NA
+1481	NA	government-organisation:PB197	S.1311	NA	NA
+3542	Nuclear Flask Hire Limited (s. BNG / BNFL)	NA	S.11001	NA	NA
+3543	Nuclear Generation Decommissioning Fund Ltd	NA	S.11001	NA	NA
+3544	Nuclear Liabilities Fund Trust Company	NA	S.1311	NA	NA
+3545	Nuclear Powered Warships Safety Committee	NA	S.1311	NA	NA
+1482	NA	government-organisation:PB400	S.1311	1905-06-24	NA
+3546	Nuclear Transport Limited (s. BNG / BNFL)	NA	S.11001	NA	NA
+3547	Nuclear Weapons Safety Committee	NA	S.1311	NA	NA
+1483	NA	local-authority-eng:NUN	S.1313	NA	NA
+3548	Nuneaton and Bedworth Leisure Trust	NA	S.1313	NA	NA
+3549	Nursery Channel Ltd. (S - S4C) (The)	NA	S.11001	NA	NA
+3551	Nurses, Midwives, Health Visitors and Professions Allied to Medicine Pay Review Body	NA	S.1311	NA	NA
+3550	Nurses', Midwives' and other NHS Professions Review Body	NA	S.1311	NA	NA
+3552	Nursing and Midwifery Council, The	NA	S.1311	2002-01-01	NA
+3553	Oadby and Wigston District Council	NA	S.1313	NA	NA
+3559	Oban Port	NA	S.1313	NA	NA
+3560	OBRIC Publications Ltd - (s LDDC)	NA	S.11001	NA	NA
+3561	Occupational Pensions Board	NA	S.1311	NA	NA
+3562	Occupational Pensions Regulatory Authority (OPRA)	NA	S.1311	NA	NA
+1484	NA	government-organisation:PB260	S.1311	2011-03-01	NA
+1485	NA	government-organisation:PB134	S.1311	NA	NA
+3569	Office for Judicial Complaints	NA	S.1311	2006-04-01	NA
+3570	Office for Legal Complaints	NA	S.1311	NA	NA
+1486	NA	government-organisation:D303	S.1311	NA	NA
+1743	NA	government-organisation:PC1059	S.11001	2014-03-01	NA
+3571	Office for Standard in Education children's Services and Skills (Ofsted)	NA	S.1311	NA	NA
+3572	Office for the Regulation of Electricity and Gas (OFREG) (Northern Ireland)	NA	S.1311	NA	2007-04-01
+3573	Office of Communications (Ofcom)	NA	S.1311	1905-06-24	NA
+3574	Office of Electricity Regulation	NA	S.1311	NA	NA
+1487	NA	government-organisation:D352	S.1311	NA	NA
+3575	Office of Gas and Electricity Markets (OFGEM)	NA	S.1311	NA	NA
+3576	Office of Gas Supply	NA	S.1311	NA	NA
+3577	Office of Government Commerce	NA	S.1311	NA	NA
+1878	NA	government-organisation:OT945	S.1311	NA	2012-07-01
+3579	Office of Her Majesty's Chief Inspector of Schools in England	NA	S.1311	NA	NA
+3578	Office of Her Majesty’s Chief Inspector of Education and Training in Wales (Estyn)	NA	S.1311	NA	NA
+3580	Office of Passenger Rail Franchising	NA	S.1311	NA	NA
+3581	Office of Public Service	NA	S.1311	NA	NA
+3582	Office of Public Services and Science (OPSS)	NA	S.1311	NA	NA
+3583	Office of Qualifications and Examinations Regulator (Ofqual)	NA	S.1311	NA	NA
+1750	NA	government-organisation:D110	S.1311	NA	NA
+1488	NA	government-organisation:PB457	S.1311	NA	NA
+1755	NA	government-organisation:OT977	S.1311	NA	NA
+3584	Office of the Adjudicator - Broadcast Transmission Services	NA	S.1311	2008-09-01	NA
+3585	Office of the Chief Investigating Officer (Scotland)	NA	S.1311	NA	2011-04-01
+1489	NA	government-organisation:PB413	S.1311	NA	NA
+3586	Office of the Commissioner for Public Appointments	NA	S.1311	NA	NA
+3587	Office of the Commissioner for Public Appointments in Scotland	NA	S.1311	NA	2011-04-01
+3588	Office of the Data Protection Commissioner	NA	S.1311	NA	NA
+1490	NA	government-organisation:OT979	S.1311	NA	NA
+3589	Office of the Deputy Prime Minister (ODPM)	NA	S.1311	NA	NA
+1491	NA	government-organisation:PB263	S.1311	NA	NA
+3590	Office of the Information Commissioner	NA	S.1311	NA	NA
+3591	Office of the Northern Ireland Commissioner for Administration	NA	S.1311	NA	NA
+3592	Office of the Northern Ireland Commissioner for Complaints	NA	S.1311	NA	NA
+1829	Office of the Parliamentary Commissioner and Health Service Commissioners	NA	S.1311	NA	NA
+1818	NA	government-organisation:OT618	S.1311	NA	NA
+3593	Office of the Rail Regulator and International Rail Regulator (ORR)	NA	S.1311	NA	NA
+3594	Office of the Scottish Charity Regulator (OSCR)	NA	S.1311	2003-12-01	NA
+3595	Office of the Scottish Parliamentary Standards Commissioner	NA	S.1311	NA	2011-04-01
+1492	NA	government-organisation:D24	S.1311	NA	NA
+3596	Office of Water Services (OFWAT)	NA	S.1311	NA	NA
+3597	Offshore Energy Technology Board	NA	S.1311	NA	NA
+3598	Offshore Industry Liaison Committee	NA	S.1311	NA	NA
+3599	OFWAT National Customer Council	NA	S.1311	NA	NA
+1879	NA	government-organisation:OT817	S.11001	NA	NA
+3601	Oil and Gas Projects and Supplies Office Board	NA	S.1311	NA	NA
+1844	NA	government-organisation:PB401	S.11001	NA	NA
+4856	Oldham Coliseum Theatre Ltd, The	NA	S.1313	NA	NA
+4857	Oldham Economic Development Association Ltd	NA	S.1313	NA	NA
+1493	NA	local-authority-eng:OLD	S.1313	NA	NA
+1494	NA	government-organisation:PB181	S.1311	NA	2014-12-02
+4858	Olympic Lottery Distributor	NA	S.1311	NA	2013-04-01
+4859	Olympic Park Legacy Company	NA	S.1313	NA	2012-04-01
+1832	NA	government-organisation:EA921	S.1311	NA	2012-07-01
+1495	NA	government-organisation:D38	S.11001	NA	NA
+1496	NA	government-organisation:EA695	S.1311	NA	NA
+4875	Orford Town Trustees	NA	S.11001	NA	NA
+4879	Orkney Harbour Commissioners	NA	S.1313	NA	NA
+1497	NA	local-authority-sct:ORK	S.1313	NA	NA
+4883	Osel Enterprises Ltd	NA	S.1313	NA	NA
+4887	Overseas Project Board	NA	S.1311	NA	NA
+4888	Overseas Service Pensions Scheme Advisory Board	NA	S.1311	NA	2006-02-01
+1498	NA	local-authority-eng:OXO	S.1313	NA	NA
+1499	NA	local-authority-eng:OXF	S.1313	NA	NA
+4891	Pacific Nuclear Transport Limited (s. BNG / BNFL)	NA	S.11001	NA	NA
+4894	Paignton Port	NA	S.1313	NA	NA
+4898	Papa Westray Aerodrome	NA	S.1313	NA	NA
+4900	Parades Commission	NA	S.1311	NA	NA
+4907	Parcelforce Worldwide - (s C)	NA	S.11001	NA	NA
+4908	Parish Councils (England)	NA	S.1313	NA	NA
+1814	NA	government-organisation:OT519	S.1311	NA	NA
+4913	Parliamentary Boundary Commission for England	NA	S.1311	NA	NA
+4914	Parliamentary Boundary Commission for Wales	NA	S.1311	NA	NA
+4915	Parole Board for England and Wales	NA	S.1311	NA	NA
+4916	Parole Board for Scotland	NA	S.1311	NA	NA
+1727	NA	government-organisation:OT875	S.1311	NA	NA
+4920	Partnership Fund Assessment Panel	NA	S.1311	NA	NA
+4921	Partnerships for Church of England Schools	NA	S.1311	NA	2006-12-01
+4922	Partnerships for Schools	NA	S.1311	NA	2012-06-01
+4923	Partnerships UK	NA	S.11001	NA	NA
+4926	Passenger Transport Authorities (En Bloc)	NA	S.1313	NA	2009-02-01
+4927	Passenger Transport Executive Group Ltd (PTEG Ltd)	NA	S.1311	2006-06-01	NA
+4928	Passenger Transport Executives (PTE)	NA	S.1313	1998-04-01	NA
+4929	Patent Office (t/a The UK Intellectual Property Office)	NA	S.11001	NA	NA
+4931	Patient Client Council	NA	S.1311	NA	NA
+4932	Patient Client Council (Northern Ireland)	NA	S.1311	2009-04-01	NA
+1500	NA	government-organisation:OT545	S.1313	1996-06-01	NA
+4942	Pembrokeshire Coast National Park Authority	NA	S.1313	1995-11-01	NA
+1501	NA	principal-local-authority:PEM	S.1313	NA	NA
+1502	NA	local-authority-eng:PEN	S.1313	NA	NA
+4948	Pennan Harbour	NA	S.11001	NA	2015-12-02
+4950	Penryn Port	NA	S.1313	NA	NA
+1503	NA	government-organisation:PB348	S.12801	NA	NA
+1504	NA	government-organisation:EA924	S.1311	2008-03-01	NA
+4951	Pensions Advisory Service, The	NA	S.1311	NA	NA
+4952	Pensions Appeal Tribunal	NA	S.1311	NA	NA
+4953	Pensions Appeal Tribunal for Scotland	NA	S.1311	NA	1905-06-24
+4954	Pensions Compensation Board	NA	S.1311	NA	NA
+4955	Pensions Ombudsman, The	NA	S.1311	NA	NA
+4956	Pensions Regulator, The	NA	S.1311	NA	NA
+4958	Penzance Port	NA	S.1313	NA	NA
+4959	People and Arts (Latin Am) LLC [USA] (50%) (sBBCW) (Associate)	NA	S.11001	NA	NA
+1505	NA	government-organisation:EA882	S.1311	NA	2011-07-01
+4961	People's Panel Advisory Group	NA	S.1311	NA	NA
+1506	NA	government-organisation:OT903	S.1311	NA	2008-04-01
+4964	Persons Hearing Consumer Credit Licensing Appeals	NA	S.1311	NA	NA
+4965	Persons Hearing Estate Agents Appeal	NA	S.1311	NA	NA
+1840	NA	local-authority-sct:PKN	S.1313	NA	NA
+4966	Perth Port	NA	S.1313	NA	NA
+4967	Pesticides Residue Committee	NA	S.1311	NA	NA
+4970	Peterborough - (s NTC)	NA	S.1311	NA	NA
+1507	NA	local-authority-eng:PTE	S.1313	NA	NA
+4971	Peterhead Port	NA	S.11001	NA	2015-12-02
+4972	Peterlee - (s NTC)	NA	S.1311	NA	NA
+4974	Pharmacists’ Review Panel	NA	S.1311	NA	NA
+4975	Phillips Port (Caithness)	NA	S.1313	NA	NA
+4979	PhonepayPlus	NA	S.1311	2007-12-01	NA
+4982	Pig Production Development Committee	NA	S.1311	NA	NA
+4992	Pirbright Institute	NA	S.1311	NA	2013-12-01
+4993	Pittenweem Port	NA	S.1313	NA	NA
+4994	Place Names Advisory Committee	NA	S.1311	NA	NA
+4998	Planning Appeals Commission	NA	S.1311	NA	NA
+1508	NA	government-organisation:EA39	S.1311	NA	NA
+4999	Planning Service (Northern Ireland)	NA	S.1311	NA	2011-04-01
+1509	NA	government-organisation:PB423	S.1311	NA	NA
+5006	Plymouth (Roborough) Aerodrome	NA	S.1313	NA	NA
+5008	Plymouth City Bus Ltd	NA	S.11001	NA	2009-12-01
+1510	NA	local-authority-eng:PLY	S.1313	NA	NA
+5010	Plymouth Development Corporation	NA	S.11001	NA	NA
+5011	Plymouth Marine Laboratory	NA	S.1311	NA	NA
+5012	Plymouth Marines Application Ltd	NA	S.11001	NA	NA
+5013	Pneumoconiosis Workers Compensation Board	NA	S.1311	NA	NA
+5015	Pointsforlife Ltd	NA	S.1311	2009-07-01	NA
+5016	Poisons Board	NA	S.1311	NA	NA
+5017	Poisons Board (Northern Ireland)	NA	S.1311	NA	NA
+1511	NA	government-organisation:PB273	S.1311	NA	NA
+5018	Police Advisory Board for Scotland	NA	S.1311	NA	NA
+5019	Police and Crime Commissioners (En bloc)	NA	S.1313	2012-11-01	NA
+1512	NA	government-organisation:PB277	S.1311	NA	NA
+5020	Police Authorities (En Bloc)	NA	S.1313	NA	2012-11-01
+5021	Police Authority for Northern Ireland	NA	S.1311	NA	NA
+1513	NA	government-organisation:OT727	S.1311	NA	NA
+1514	NA	government-organisation:PB278	S.1311	NA	NA
+5022	Police Forces (En Bloc)	NA	S.1313	NA	NA
+5023	Police Forces (Scotland) (En Bloc)	NA	S.1313	NA	NA
+1728	NA	government-organisation:EA832	S.1311	NA	NA
+1515	NA	government-organisation:PB458	S.1311	NA	NA
+5024	Police Ombudsman for Northern Ireland (Independent Commission for Police Complaints for Northern Ireland)	NA	S.1311	NA	NA
+5025	Police Rehabilitation and Retraining Trust	NA	S.1311	1905-06-21	NA
+1516	NA	government-organisation:OT657	S.1311	NA	NA
+5026	Police Service of Scotland	NA	S.1311	2013-04-01	NA
+5027	Policyholders' Protection Board	NA	S.1311	NA	2001-11-30
+5031	Poole Harbour Commissioners	NA	S.11001	NA	NA
+5032	Poole Housing Partnership Ltd	NA	S.11001	NA	NA
+5035	Port Isaac	NA	S.11001	NA	NA
+5036	Port Nahaven (Islay)	NA	S.1313	NA	NA
+5038	Port of London Authority	NA	S.11001	NA	NA
+5039	Port of Tyne Authority	NA	S.11001	NA	NA
+5040	Port Seton Harbour	NA	S.11001	NA	2015-12-02
+5045	Portree (Port)	NA	S.1313	NA	NA
+1517	NA	local-authority-eng:POR	S.1313	NA	NA
+5047	Portsmouth Port	NA	S.1313	NA	NA
+5049	Positive Lifestyles Ltd	NA	S.1313	NA	NA
+5050	Post Office Limited	NA	S.11001	1905-06-09	NA
+5051	Post Office Users' Council for Northern Ireland	NA	S.1311	NA	NA
+5052	Post Office Users' Council for Scotland	NA	S.1311	NA	NA
+5053	Post Office Users' Council for Wales	NA	S.1311	NA	NA
+5054	Post Office Users' National Council	NA	S.1311	NA	NA
+5055	Post Qualification Education Board for Health Science Pharmacists in Scotland	NA	S.1311	NA	NA
+1518	NA	government-organisation:OT834	S.1311	NA	NA
+5056	Postal Services Holding Company Plc	NA	S.11001	NA	2012-04-01
+5057	Postal Services Holding Company Plc.	NA	S.1311	2000-09-01	NA
+5058	PostCap (Guernsey) Ltd. (Guernsey) - (s C)	NA	S.11001	NA	NA
+5059	Potato Council Ltd	NA	S.1311	NA	NA
+5060	Potato Industry Development Council	NA	S.1311	NA	NA
+5061	Potteries Box Company Ltd - (s Remploy Ltd) (The)	NA	S.11001	NA	NA
+1519	NA	principal-local-authority:POW	S.1313	NA	NA
+5063	Powys Teaching Health Board	NA	S.1311	2006-06-01	NA
+5065	PPP Arbiter	NA	S.1313	NA	2010-10-01
+1520	NA	government-organisation:OT806	S.1311	NA	2006-04-01
+1521	NA	local-authority-eng:PRE	S.1313	NA	NA
+5067	Prestwick Airport Infrastructure Limited	NA	S.11001	2013-11-22	NA
+5068	Prestwick Airport Limited	NA	S.11001	2013-11-22	NA
+5069	Prestwick Airport Property Limited	NA	S.11001	2013-11-22	NA
+5070	Prestwick Aviation Holdings Limited	NA	S.1311	2013-11-22	NA
+5071	Primary Care Trusts (En Bloc)	NA	S.1311	NA	2013-04-01
+5075	Priority Sites Ltd	NA	S.11001	2008-09-01	NA
+5860	Private registered providers (PRPs) of social housing in England	NA	S.11001	1996-07-24	NA
+1522	NA	government-organisation:OT342	S.1311	NA	NA
+1523	NA	government-organisation:OT659	S.1311	NA	NA
+5076	Probation Trusts	NA	S.1311	NA	NA
+5081	Property Advisors to the Civil Estate (PACE)	NA	S.1311	NA	NA
+5082	Property Advisory Group	NA	S.1311	NA	2003-07-01
+5085	Proteus Theatre Co Ltd	NA	S.1313	NA	NA
+5086	Proudman Oceanographic Laboratory	NA	S.1311	NA	NA
+5089	Prudential Regulation Authority	NA	S.12601	2013-04-01	NA
+5090	Public Guardian Board	NA	S.1311	NA	2012-09-01
+5091	Public Guardianship Office	NA	S.1311	NA	2007-10-01
+1524	NA	government-organisation:EA480	S.1311	2013-04-01	NA
+1525	NA	government-organisation:EA660	S.1311	NA	2005-04-01
+1770	NA	government-organisation:OT1077	S.1311	2009-08-01	NA
+1866	Public Lending Right and the Public Lending Right Advisory Committee	NA	S.1311	NA	1905-07-01
+5092	Public Private Partnerships Programme Ltd (4ps)	NA	S.1313	2009-08-01	NA
+1526	NA	government-organisation:OT962	S.1311	2005-06-01	NA
+5093	Public Record Office	NA	S.1311	NA	NA
+5094	Public Records Office of Northern Ireland	NA	S.1311	NA	NA
+5095	Public Service Commission	NA	S.1311	2006-03-01	NA
+5096	Public Service Training Council Northern Ireland	NA	S.1311	NA	NA
+5097	Public Services Ombudsman for Wales	NA	S.1311	NA	NA
+5098	Public Services Productivity Panel Unit	NA	S.1311	NA	2002-05-01
+5099	Public Trust Office	NA	S.1311	NA	NA
+1527	NA	local-authority-eng:PUR	S.1313	NA	NA
+5102	QinetiQ	NA	S.11001	NA	NA
+1528	NA	government-organisation:EA956	S.1311	NA	2012-04-01
+5104	Qualifications, Curriculum and Assessment Authority for Wales	NA	S.1311	NA	2006-04-01
+5105	Quality Meat Scotland	NA	S.1311	2008-04-01	NA
+5106	Quality Space (Stirling) Ltd	NA	S.1313	NA	NA
+1529	NA	government-organisation:EA40	S.11001	NA	NA
+5107	Queen Victoria School	NA	S.1311	NA	2005-04-01
+5108	Queen Victoria School (Charity)	NA	S.1311	2006-04-01	NA
+5111	Race Education and Employment Forum	NA	S.1311	NA	NA
+5112	Race Relations Employment Advisory Group	NA	S.1311	NA	NA
+5113	Race Relations Forum	NA	S.1311	NA	NA
+5117	Radio Authority	NA	S.1311	NA	NA
+5118	Radioactive Waste Management Advisory Committee	NA	S.1311	NA	NA
+1756	NA	government-organisation:OT1150	S.1311	2014-04-01	NA
+5119	Radiocommunications Agency	NA	S.1311	NA	NA
+5120	RAF Logistics Support Services	NA	S.1311	NA	NA
+5121	RAF Maintenance Group Defence Agency	NA	S.1311	NA	NA
+5122	RAF Personnel Management Agency	NA	S.1311	NA	2004-04-01
+5123	RAF Signals Engineering Establishment	NA	S.1311	NA	NA
+5124	RAF Training Group Defence Agency	NA	S.1311	NA	2006-04-01
+5125	Rail for London Ltd	NA	S.11001	2011-04-01	NA
+5126	Rail Passengers' Committees	NA	S.1311	NA	NA
+5127	Rail Passengers' Council	NA	S.1311	NA	NA
+5128	Rail Users’ Consultative Committees	NA	S.1311	NA	NA
+5129	Railsale Ltd	NA	S.1311	NA	NA
+5131	RAJAR (Radio Joint Audience Research) Ltd (50%) (sBBCW) (Associate)	NA	S.11001	NA	NA
+5132	Rampton Hospital Authority	NA	S.1311	NA	NA
+5134	Ramsgate Port	NA	S.1313	NA	NA
+5135	Rate Collection Agency (Northern Ireland)	NA	S.1311	NA	NA
+5136	Rathgael & White Abbey Schools Management Board	NA	S.1311	NA	NA
+5141	RCUK Shared Services Centre Ltd	NA	S.1311	2007-08-01	NA
+5143	Reactor Sites Management Company Ltd.	NA	S.11001	NA	NA
+1530	NA	local-authority-eng:RDG	S.1313	NA	NA
+5144	Reading Transport Ltd	NA	S.11001	NA	NA
+5149	Redbridge Homes Ltd	NA	S.11001	NA	2012-08-01
+1875	NA	local-authority-eng:RCC	S.1313	NA	NA
+5150	Redditch - (s NTC)	NA	S.1311	NA	NA
+1531	NA	local-authority-eng:RED	S.1313	NA	NA
+5156	Reedmonte Ltd	NA	S.1313	NA	NA
+5159	Regional Agency for Public Health and Social Well-being (Northern Ireland), The	NA	S.1311	2009-04-01	NA
+5160	Regional Aggregation Bodies	NA	S.1311	NA	NA
+5161	Regional Assemblies (England)	NA	S.1313	NA	NA
+5162	Regional Business Services Organisation	NA	S.1311	NA	NA
+5163	Regional Business Services Organisation (Northern Ireland)	NA	S.1311	2009-04-01	NA
+5164	Regional Flood Defence Committees	NA	S.1311	NA	NA
+5165	Regional Health and Social Care Board	NA	S.1311	NA	NA
+5166	Regional Health and Social Care Board (Northern Ireland)	NA	S.1311	2009-04-01	NA
+5167	Regional Health Authorities (En Bloc)	NA	S.1311	NA	1996-04-01
+5168	Regional Industrial Development Boards	NA	S.1311	NA	NA
+5169	Regional Panels in MAFF	NA	S.1311	NA	NA
+5170	Registered Homes Tribunal (Northern Ireland)	NA	S.1311	NA	NA
+5171	Registered Homes Tribunals	NA	S.1311	NA	NA
+5861	Registered Housing Associations (RHAs) in Northern Ireland	NA	S.11001	1992-07-15	NA
+5172	Registered Inspectors of Schools Appeals Tribunal	NA	S.1311	NA	NA
+5173	Registered Inspectors of Schools Appeals Tribunal (Wales)	NA	S.1311	NA	NA
+5174	Registered Nursery Education Inspectors Appeals Tribunal	NA	S.1311	NA	NA
+5862	Registered Social Landlords (RSL) in Scotland	NA	S.11001	2001-07-18	NA
+5863	Registered Social Landlords (RSLs) in Wales	NA	S.11001	1996-07-24	NA
+5175	Registers of Scotland	NA	S.11001	NA	NA
+5176	Registrar of Occupational and Personal Pension Schemes	NA	S.1311	NA	NA
+5177	Registrar of the Public Lending Right	NA	S.1311	NA	2013-10-01
+5178	Registry of Friendly Societies	NA	S.1311	NA	NA
+1532	NA	local-authority-eng:REI	S.1313	NA	NA
+5181	Renewable Energy Advisory Committee	NA	S.1311	NA	1905-06-23
+1533	NA	government-organisation:EA901	S.1311	NA	NA
+5182	Renfrew Port	NA	S.1313	NA	NA
+1873	NA	local-authority-sct:RFW	S.1313	NA	NA
+5183	Rent Assessment Panels (Northern Ireland)	NA	S.1311	NA	NA
+5184	Rent Assessment Panels (RAPS)	NA	S.1311	NA	2013-07-01
+5185	Rent Assessment Panels (Scotland)	NA	S.1311	NA	NA
+5186	Rent Assessment Panels (Wales)	NA	S.1311	NA	NA
+5187	Rent Service (The)	NA	S.1311	NA	2009-04-01
+5188	Research Councils (En Bloc)	NA	S.1311	NA	NA
+5189	Research Sites Restoration Limited	NA	S.1311	2009-02-01	NA
+5191	Residuary Bodies	NA	S.1313	NA	NA
+5192	Residuary Body for Wales	NA	S.1311	NA	NA
+5193	Resource: The Council for Museums Archives and Libraries	NA	S.1311	NA	2004-04-01
+1534	NA	government-organisation:OT867	S.1311	NA	2010-01-01
+5197	Revenue Scotland	NA	S.1311	2015-01-01	NA
+1535	NA	government-organisation:PB477	S.1311	NA	NA
+1809	NA	government-organisation:PB382	S.1311	NA	NA
+1784	NA	principal-local-authority:RCT	S.1313	NA	NA
+1536	NA	local-authority-eng:RIB	S.1313	NA	NA
+1537	NA	local-authority-eng:RIH	S.1313	NA	NA
+5208	Ringway Developments Ltd	NA	S.1313	NA	NA
+5209	Ringway Handling Limited (s MA)	NA	S.11001/3	2013-02-01	NA
+5210	Ringway Handling Services Ltd (s MA)	NA	S.11001/3	2013-02-01	NA
+5214	River Nith Navigation	NA	S.11001	NA	2015-12-02
+5215	River Yealm Harbour Authority	NA	S.11001	NA	NA
+5216	Rivers Agency (Northern Ireland)	NA	S.1311	NA	NA
+5217	Riverside Centre Ltd, The	NA	S.1313	NA	NA
+5221	RM Museum Ltd	NA	S.11001	NA	NA
+5222	RNM Functions Ltd	NA	S.11001	NA	NA
+1862	NA	government-organisation:OT831	S.1311	NA	NA
+1538	NA	local-authority-eng:RCH	S.1313	NA	NA
+1539	NA	local-authority-eng:ROC	S.1313	NA	NA
+5233	Rolls Royce PLC	NA	S.11001	NA	NA
+5238	Rosehearty Harbour	NA	S.11001	NA	2015-12-02
+1540	NA	local-authority-eng:ROS	S.1313	NA	NA
+5242	Rossendale Transport Ltd	NA	S.11001	NA	NA
+1541	NA	local-authority-eng:ROH	S.1313	NA	NA
+1542	NA	local-authority-eng:ROT	S.1313	NA	NA
+5245	Routes to Work South	NA	S.1313	NA	NA
+5246	Rowett Research Institute	NA	S.1311	NA	NA
+1543	NA	government-organisation:PB308	S.1311	NA	NA
+1544	NA	government-organisation:PB182	S.1311	NA	NA
+5249	Royal Bank of Scotland Group plc	NA	S.12501	NA	NA
+5250	Royal Bank of Scotland Group plc Subsidiaries	NA	S.12201	NA	NA
+5251	Royal Bank of Scotland plc, The	NA	S.12201	NA	NA
+1545	NA	local-authority-eng:GRE	S.1313	NA	NA
+1546	NA	local-authority-eng:KEC	S.1313	NA	NA
+1547	NA	local-authority-eng:KTT	S.1313	NA	NA
+1548	NA	local-authority-eng:WNM	S.1313	NA	NA
+5252	Royal Botanic Garden, Edinburgh	NA	S.1311	NA	NA
+5253	Royal Botanic Gardens, Kew	NA	S.1311	NA	NA
+5254	Royal Collection Enterprises Ltd	NA	S.11001	NA	NA
+5255	Royal Collection Trust	NA	S.11001	NA	NA
+5256	Royal Commission on Ancient and Historical Monuments of Scotland	NA	S.1311	NA	2015-04-01
+1549	NA	government-organisation:OT606	S.1311	NA	NA
+5257	Royal Commission on Historical Monuments in England	NA	S.1311	NA	NA
+5258	Royal Commission on Long Term Care of the Elderly	NA	S.1311	NA	NA
+5259	Royal Commission on the Ancient and Historical Monuments of Wales	NA	S.1311	NA	NA
+5260	Royal Docks Management Authority Ltd - (s LDA)	NA	S.11001	2002-04-01	NA
+5261	Royal Fine Art Commission	NA	S.1311	NA	1905-06-26
+5262	Royal Fine Art Commission for Scotland	NA	S.1311	NA	NA
+5263	Royal Hospital Chelsea	NA	S.1311	NA	NA
+5264	Royal Household	NA	S.1311	NA	NA
+5265	Royal Mail Plc (and subsidiaries)	NA	S.11001	NA	2013-10-01
+1550	NA	government-organisation:PB310	S.1311	NA	NA
+5266	Royal Military College of Science Advisory Council (RCMS)	NA	S.1311	NA	2004-04-01
+1551	NA	government-organisation:EA114	S.11001	NA	NA
+1782	NA	government-organisation:PB434	S.1311	NA	NA
+5267	Royal Naval Museum	NA	S.1311	NA	NA
+5268	Royal Naval Museum Trading Company Ltd.	NA	S.11001	NA	NA
+1822	NA	government-organisation:OT409	S.1311	NA	NA
+5269	Royal Observatory Greenwich	NA	S.1311	NA	NA
+5270	Royal Parks Agency	NA	S.1311	NA	NA
+5271	Royal Patriotic Fund	NA	S.1311	NA	NA
+5272	Royal Ulster Constabulary	NA	S.1311	NA	NA
+5273	Royal Ulster Constabulary George Cross Foundation	NA	S.1311	NA	NA
+1552	NA	local-authority-eng:RUG	S.1313	NA	NA
+5276	Runcorn - (s NTC)	NA	S.1311	NA	NA
+1553	NA	local-authority-eng:RUN	S.1313	NA	NA
+5277	Rural Development Commission	NA	S.1311	NA	NA
+1554	NA	government-organisation:EA58	S.1311	NA	NA
+1555	NA	local-authority-eng:RUS	S.1313	NA	NA
+1556	NA	local-authority-eng:RUH	S.1313	NA	NA
+1557	NA	local-authority-eng:RUT	S.1313	NA	NA
+5285	Ryde Port	NA	S.1313	NA	NA
+5286	Rye Harbour Commissioners	NA	S.11001	NA	NA
+1558	NA	local-authority-eng:RYE	S.1313	NA	NA
+5288	Rykneld Homes Ltd	NA	S.11001	NA	NA
+5289	S.A.D.A.C.C.A. Ltd (Sheffield and District Afro-Caribbean Community Association Ltd)	NA	S.1313	NA	NA
+5290	S.M.N.E Ltd.	NA	S.11001	NA	NA
+5291	S4C Masnachol Cyf - (s S4C)	NA	S.11001	NA	NA
+5292	S4C Rhyngwladol Cyf. (S - S4C)	NA	S.11001	NA	NA
+1801	S4C2 Cyf. (S - S4C)	NA	S.11001	NA	NA
+5295	Safefood (Food Safety Promotion Board)	NA	S.1311	1999-12-01	NA
+5300	Salcombe Port	NA	S.1313	NA	NA
+1559	NA	local-authority-eng:SLF	S.1313	NA	NA
+5303	Salix Homes Ltd	NA	S.11001	NA	NA
+5304	Salmon Advisory Council	NA	S.1311	NA	NA
+5305	Saltcoats Port	NA	S.1313	NA	NA
+5313	Sanday Aerodrome	NA	S.1313	NA	NA
+5314	Sanday Port	NA	S.1313	NA	NA
+5317	Sandwell Homeless and Resettlement Project Ltd	NA	S.1313	NA	NA
+5318	Sandwell Homes Ltd	NA	S.11001	NA	2013-01-01
+1560	NA	local-authority-eng:SAW	S.1313	NA	NA
+5319	Sandwell Tenants and Residents Federation Ltd	NA	S.1313	NA	NA
+5320	Sandwich Port and Haven Commissioners	NA	S.11001	NA	NA
+5322	Satman Developments	NA	S.1313	NA	NA
+5323	Saundersfoot Harbour Commissioners	NA	S.11001	NA	NA
+1561	NA	local-authority-eng:SCE	S.1313	NA	NA
+5325	Scarborough Port	NA	S.1313	NA	NA
+5326	School Examinations and Assessment Council	NA	S.1311	NA	NA
+1562	NA	government-organisation:OT938	S.1311	NA	2011-09-01
+5327	School Support Staff Negotiating Body	NA	S.1311	NA	2012-02-01
+1779	NA	government-organisation:PB414	S.1311	NA	NA
+1799	NA	government-organisation:PB402	S.1311	2009-07-01	NA
+1563	NA	government-organisation:PB135	S.1311	NA	NA
+1564	NA	government-organisation:PB177	S.1311	2012-04-01	NA
+5328	Scientific Advisory Committee on Nutrition	NA	S.1311	NA	NA
+5329	Scientific Committee on Tobacco and Health	NA	S.1311	NA	NA
+5330	SCMG Enterprises Ltd	NA	S.11001	1987-11-01	NA
+1565	NA	government-organisation:D23	S.1311	NA	NA
+5331	Scotland's Commissioner for Children and Young People	NA	S.1311	NA	NA
+5332	Scottish Advisory Committee on Distinction Awards	NA	S.1311	NA	NA
+5333	Scottish Advisory Committee on Drug Misuse	NA	S.1311	NA	1905-06-24
+5334	Scottish Advisory Committee on Telecommunications	NA	S.1311	NA	2003-12-29
+5335	Scottish Advisory Committee on the Medical Workforce	NA	S.1311	NA	1905-06-24
+5336	Scottish Agricultural College	NA	S.1311	NA	NA
+5337	Scottish Agricultural Consultative Panel	NA	S.1311	NA	NA
+5338	Scottish Agricultural Wages Board	NA	S.1311	NA	NA
+5339	Scottish Ambulance Service Board	NA	S.1311	NA	NA
+1566	NA	government-organisation:OT762	S.1311	NA	2010-07-01
+5340	Scottish Association of Citizens Advice Bureau (The)	NA	S.1311	2005-04-01	NA
+1845	NA	local-authority-sct:SCB	S.1313	NA	NA
+5342	Scottish Canals	NA	S.1311	2012-07-01	NA
+5343	Scottish Child-Care Board	NA	S.1311	NA	NA
+5344	Scottish Children's Reporter Administration	NA	S.1311	NA	NA
+5345	Scottish Commission for the Regulation of Care	NA	S.1311	NA	2011-04-01
+5346	Scottish Consolidated Fund	NA	S.1311	NA	NA
+5347	Scottish Consultative Council on the Curriculum	NA	S.1311	NA	NA
+5348	Scottish Consumer Council	NA	S.1311	NA	NA
+5349	Scottish Conveyancing and Executry Services Board	NA	S.1311	NA	NA
+5350	Scottish Council for Educational Technology	NA	S.1311	NA	NA
+5351	Scottish Council for Post-Graduate Medical Education and Dental Education	NA	S.1311	NA	1905-06-24
+5352	Scottish Council for Research in Education	NA	S.1311	NA	NA
+5353	Scottish Courts (En Bloc)	NA	S.1311	NA	NA
+5354	Scottish Crime Prevention Council	NA	S.1311	NA	NA
+5355	Scottish Criminal Cases Review Commission	NA	S.1311	NA	NA
+5356	Scottish Crop Research Institute	NA	S.1311	NA	1905-06-24
+5357	Scottish Development Agency	NA	S.1311	NA	NA
+5358	Scottish Economic Council	NA	S.1311	NA	NA
+5359	Scottish Education Department	NA	S.1311	NA	NA
+5360	Scottish Enterprise	NA	S.1311	NA	NA
+5361	Scottish Environment Protection Agency	NA	S.1311	NA	NA
+5362	Scottish Examination Board	NA	S.1311	NA	NA
+5363	Scottish Film Council	NA	S.1311	NA	NA
+5364	Scottish Fire and Rescue Service	NA	S.1311	2013-04-01	NA
+5365	Scottish Fisheries Protection Agency	NA	S.1311	NA	2009-04-01
+5366	Scottish Further & Higher Education Funding Council (Scottish Funding Council)	NA	S.1311	NA	NA
+5367	Scottish Further Education Funding Council	NA	S.1311	NA	NA
+5368	Scottish Further Education Unit	NA	S.1311	NA	NA
+5369	Scottish Futures Trust Ltd	NA	S.1311	2008-09-01	NA
+1567	NA	government-organisation:DA1020	S.1311	NA	NA
+5370	Scottish Higher Education Funding Council	NA	S.1311	NA	NA
+5371	Scottish Homes	NA	S.11001	NA	NA
+5372	Scottish Homes Residuary Body	NA	S.1311	NA	1905-06-24
+5373	Scottish Hospital Endowments Research Trust	NA	S.1311	NA	1905-06-24
+1568	NA	government-organisation:OT989	S.1311	NA	NA
+5374	Scottish Housing Regulator	NA	S.1311	2011-04-01	NA
+5375	Scottish Human Rights Commission	NA	S.1311	NA	NA
+5376	Scottish Industrial Development Advisory Board	NA	S.1311	NA	2011-04-01
+5377	Scottish Information Commissioner	NA	S.1311	NA	NA
+5378	Scottish Joint Industry Board	NA	S.1311	NA	NA
+1569	NA	government-organisation:OT612	S.1311	NA	NA
+5379	Scottish Legal Aid Board	NA	S.1311	NA	NA
+5380	Scottish Legal Complaints Commission	NA	S.1311	NA	NA
+5381	Scottish Medical Practices Committee	NA	S.1311	NA	NA
+5382	Scottish Natural Heritage	NA	S.1311	NA	NA
+5383	Scottish Office Pensions Agency	NA	S.1311	NA	NA
+5384	Scottish Parliamentary Corporate Body	NA	S.1311	NA	NA
+5385	Scottish Police Services Authority	NA	S.1311	NA	2013-04-01
+5386	Scottish Policing Authority	NA	S.1311	2013-04-01	NA
+5387	Scottish Prison Service	NA	S.1311	NA	NA
+5388	Scottish Public Pensions Agency	NA	S.1311	NA	NA
+5389	Scottish Public Services Ombudsman	NA	S.1311	NA	NA
+5390	Scottish Qualifications Authority	NA	S.1311	NA	NA
+5391	Scottish Record Office	NA	S.1311	NA	NA
+5392	Scottish Records Advisory Council	NA	S.1311	NA	2011-04-01
+5393	Scottish Regional Transport Partnerships (En Bloc)	NA	S.1313	2005-12-01	NA
+5394	Scottish River Purification Boards	NA	S.1313	NA	1995-10-01
+1570	NA	government-organisation:OT642	S.1311	NA	2010-07-01
+5395	Scottish Social Services Council	NA	S.1311	NA	NA
+1571	NA	government-organisation:EA764	S.1311	NA	NA
+5396	Scottish Standing Committee for the Calculation of Residual Values of Fertilisers and Feeding stuffs	NA	S.1311	NA	1905-06-24
+5397	Scottish Studentship Selection Committee	NA	S.1311	NA	NA
+5398	Scottish University for Industry (trading as Learn Direct Scotland)	NA	S.1311	NA	NA
+5399	Scottish Valuation and Rating Council	NA	S.1311	NA	1905-06-24
+5401	Scottish Vocational and Education Council	NA	S.1311	NA	NA
+5402	Scottish Water	NA	S.11001	NA	NA
+5403	Scottish Water and Sewerage Customers Council	NA	S.1311	NA	NA
+5404	Scottish Water Solutions	NA	S.11001	NA	NA
+5405	Scottish Widows Bank plc	NA	S.12201	NA	2014-03-01
+5406	Scrabster Harbour	NA	S.11001	NA	2015-12-02
+1572	NA	government-organisation:OT205	S.1311	NA	NA
+5407	Sea Fisheries Committees	NA	S.1313	NA	2011-03-01
+5410	Secretary of State for Scotland's Advisory Group on Sustainable Development	NA	S.1311	NA	NA
+5411	Secretary of State's (Electricity) Fisheries Committee (a.k.a. Fisheries Electricity Committee)	NA	S.1311	NA	NA
+5412	Secretary of State's Advisory Committee on Scotland’s Travelling People	NA	S.1311	NA	1905-06-21
+5413	Secretary of State's Advisory Group on Sustainable Development	NA	S.1311	NA	NA
+5414	Secretary of State's Advisory Panel of Economic Consultants	NA	S.1311	NA	1905-06-21
+5415	Secretary of State's Salmon Task Force	NA	S.1311	NA	NA
+5416	Section 706 Tribunal	NA	S.1311	NA	NA
+5417	Sector Skills Development Agency	NA	S.1311	NA	NA
+5418	Security and Intelligence Services	NA	S.1311	NA	NA
+5419	Security Commission	NA	S.1311	NA	2010-10-01
+5420	Security Facilities Executive	NA	S.1311	NA	NA
+1573	NA	government-organisation:PB264	S.1311	NA	NA
+5421	Security Service Tribunal	NA	S.1311	NA	NA
+1574	NA	government-organisation:PB367	S.1311	NA	NA
+1575	NA	local-authority-eng:SEG	S.1313	NA	NA
+1576	NA	local-authority-eng:SFT	S.1313	NA	NA
+5422	Seirbheis nam Meadhanan Gàidhlig (MG Alba)	NA	S.1311	1905-06-12	NA
+1577	NA	local-authority-eng:SEL	S.1313	NA	NA
+5423	Sellafield Ltd	NA	S.11001	NA	NA
+1578	NA	government-organisation:PB368	S.1311	NA	NA
+5427	Sentencing Advisory Panel	NA	S.1311	NA	NA
+1579	NA	government-organisation:D115	S.1311	NA	NA
+1747	NA	government-organisation:PB265	S.1311	NA	2013-10-01
+1780	NA	government-organisation:EA49	S.1311	NA	2013-03-01
+1580	NA	government-organisation:EA50	S.1311	NA	2011-06-01
+1581	NA	local-authority-eng:SEV	S.1313	NA	NA
+5441	Shared Services Connect Limited (SSC)	NA	S.11001	2013-11-01	NA
+5442	Sharpness (Gloucester) - (s BWB)	NA	S.11001	NA	NA
+1582	NA	local-authority-eng:SHF	S.1313	NA	NA
+5444	Sheffield Development Corporation	NA	S.11001	NA	NA
+5445	Sheffield Homes Ltd	NA	S.11001	NA	2013-04-01
+1583	NA	local-authority-eng:SHE	S.1313	NA	NA
+5452	Shetland Charitable Trust	NA	S.1313	NA	NA
+5453	Shetland Heat energy and Power Ltd	NA	S.11001	NA	NA
+1584	NA	local-authority-sct:ZET	S.1313	NA	NA
+5454	Shetland Leasing and Property Developments Ltd	NA	S.11001	NA	NA
+5457	Ship Support Agency	NA	S.1311	NA	NA
+5460	Shoreham Aerodrome	NA	S.1313	NA	NA
+5461	Shoreham Port Authority	NA	S.11001	NA	NA
+1585	NA	local-authority-eng:SHR	S.1313	NA	NA
+5468	Shropshire Towns and Rural Housing Ltd	NA	S.11001	2013-04-01	NA
+5469	Sianel Pedwar Cymru (S4C) (Welsh Fourth Channel Authority)	NA	S.1311	NA	NA
+1741	NA	government-organisation:PB1093	S.1311	NA	NA
+1786	NA	government-organisation:PB183	S.1311	NA	NA
+5478	SITPRO Limited (Simpler Trade Procedures Board)	NA	S.1311	NA	NA
+5481	Sixth Form College Corporations (England)	NA	S.1313	NA	2012-04-01
+5482	Skelmersdale - (s NTC)	NA	S.1311	NA	NA
+5483	Skerray Harbour	NA	S.11001	NA	2015-12-02
+5484	Skills Development Scotland Co. Limited (t/a Skills Development Scotland) (The)	NA	S.1311	NA	NA
+1586	NA	government-organisation:EA86	S.1311	NA	NA
+5485	Skills Task Force	NA	S.1311	NA	NA
+5487	Skipton Fund Ltd	NA	S.1311	NA	NA
+1587	NA	local-authority-eng:SLG	S.1313	NA	NA
+5491	Small Business Service	NA	S.1311	NA	NA
+5494	Snowdonia National Park Authority	NA	S.1313	2005-11-01	NA
+5495	Social Care and Social Work Improvement Scotland (t/a Care Inspectorate)	NA	S.1311	2010-04-01	NA
+5496	Social Fund	NA	S.1311	NA	NA
+1867	NA	government-organisation:PB578	S.1311	NA	NA
+1588	NA	government-organisation:PB232	S.1311	NA	NA
+1774	NA	government-organisation:EA756	S.1311	NA	NA
+5497	Social Security Appeal Tribunals	NA	S.1311	NA	NA
+5498	Social Security Information Technology Services Agency	NA	S.1311	NA	NA
+5499	Social Services Inspectorate for Wales Advisory Group (WO)	NA	S.1311	NA	NA
+5506	Solihull community Housing Ltd	NA	S.11001	NA	NA
+1589	NA	local-authority-eng:SOL	S.1313	NA	NA
+5509	Somerset Careers Ltd	NA	S.1313	NA	NA
+1590	NA	local-authority-eng:SOM	S.1313	NA	NA
+1855	NA	local-authority-sct:SAY	S.1313	NA	NA
+5515	South Buckinghamshire District Council	NA	S.1313	NA	NA
+1591	NA	local-authority-eng:SCA	S.1313	NA	NA
+1592	NA	local-authority-eng:SDE	S.1313	NA	NA
+1593	NA	government-organisation:OT546	S.1313	2010-04-01	NA
+5519	South East England Cultural Consortium	NA	S.1311	NA	2010-09-01
+1594	NA	government-organisation:EA919	S.1311	NA	2012-07-01
+5520	South East of Scotland Transport Partnership (SESTRAN)	NA	S.1313	2005-12-01	NA
+1595	NA	government-organisation:OT857	S.1311	NA	NA
+5521	South Eastern Health and Social Care Trust	NA	S.1311	2010-04-01	NA
+5522	South Eastern Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+5523	South Eastern Trains Ltd	NA	S.11001	NA	NA
+5524	South Essex Homes Ltd	NA	S.11001	NA	NA
+1596	NA	local-authority-eng:SGC	S.1313	NA	NA
+1597	NA	local-authority-eng:SHA	S.1313	NA	NA
+1598	NA	local-authority-eng:SHO	S.1313	NA	NA
+1599	NA	local-authority-eng:SKE	S.1313	NA	NA
+1600	NA	local-authority-eng:SLA	S.1313	NA	NA
+1841	NA	local-authority-sct:SLK	S.1313	NA	NA
+1601	NA	local-authority-eng:SNO	S.1313	NA	NA
+1602	NA	local-authority-eng:SNR	S.1313	NA	NA
+5529	South of Scotland Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+1603	NA	local-authority-eng:SOX	S.1313	NA	NA
+5530	South Queensferry Port	NA	S.1313	NA	NA
+1604	NA	local-authority-eng:SRI	S.1313	NA	NA
+1605	NA	local-authority-eng:SSO	S.1313	NA	NA
+1869	NA	local-authority-eng:SST	S.1313	NA	NA
+1606	NA	local-authority-eng:STY	S.1313	NA	NA
+5534	South Tyneside Homes Ltd	NA	S.11001	NA	NA
+5537	South Wales Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+1860	NA	government-organisation:EA918	S.1311	NA	2012-07-01
+5538	South West of Scotland Transport Partnership (Swestrans)	NA	S.1313	2005-12-01	NA
+5539	South West Regional Cultural Consortium	NA	S.1311	NA	2010-09-01
+5541	South Western Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+5542	South Yorkshire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+5544	South Yorkshire Light Rail Ltd - (s SYPTE)	NA	S.11001	NA	NA
+5545	South Yorkshire Metro Ltd - (s SYPTE)	NA	S.11001	NA	NA
+5546	South Yorkshire Passenger Transport Authority	NA	S.1313	NA	NA
+5547	South Yorkshire Passenger Transport Executive - (s PTE)	NA	S.11001	NA	NA
+5548	South Yorkshire Passenger Transport Executive - (s PTE) trading as Travel South Yorkshire	NA	S.1313	1998-04-01	NA
+5549	South Yorkshire Supertram Ltd	NA	S.11001	NA	NA
+5550	South Yorkshire Transportation Systems Ltd - (s SYPTE)	NA	S.11001	NA	NA
+1607	NA	local-authority-eng:STH	S.1313	NA	NA
+5553	Southend Port	NA	S.1313	NA	NA
+1608	NA	local-authority-eng:SOS	S.1313	NA	NA
+5554	Southend-on-Sea Industrial Association Ltd	NA	S.1313	NA	NA
+5556	Southern Education and Library Board	NA	S.1311	NA	NA
+1858	NA	government-organisation:OT864	S.1311	NA	NA
+5557	Southern Health and Social Care Trust	NA	S.1311	2010-04-01	NA
+5560	Southern Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+5562	Southport (Birkdale) Aerodrome	NA	S.1313	NA	NA
+5570	Special Education Needs Tribunal (SENT)	NA	S.1311	NA	NA
+5571	Special European Union Programmes Body	NA	S.1311	1999-12-01	NA
+5572	Special Health Authorities	NA	S.1311	NA	NA
+5573	Special Hospital Services Authority	NA	S.1311	NA	NA
+5574	Specialist Advisory Committee on Antimicrobial Resistance	NA	S.1311	NA	NA
+5575	Specialist Procurement Services	NA	S.1311	NA	NA
+5577	Spectrum Management Advisory Group	NA	S.1311	NA	NA
+1609	NA	local-authority-eng:SPE	S.1313	NA	NA
+5578	Spencer (Banbury) Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+5582	Spoliation Advisory Panel	NA	S.1311	NA	NA
+5583	Spongiform Encephalopathy Advisory Committee	NA	S.1311	NA	2011-03-01
+1610	NA	government-organisation:PB190	S.1311	NA	NA
+5584	Sport on Four Ltd - (s C4)	NA	S.11001	NA	NA
+1611	NA	government-organisation:OT694	S.1311	NA	NA
+1612	NA	government-organisation:OT734	S.1311	NA	NA
+5585	Sports Council for Wales National Lottery	NA	S.1311	NA	NA
+5586	Sports Council Trust Company	NA	S.1311	NA	NA
+1794	NA	government-organisation:PB184	S.1311	NA	NA
+5587	Sportscotland	NA	S.1311	NA	NA
+5590	Springfields Fuels Limited	NA	S.11001	NA	NA
+1790	NA	local-authority-eng:SAL	S.1313	NA	NA
+5612	St. Andrews Harbour	NA	S.11001	NA	2015-12-02
+1795	NA	local-authority-eng:SED	S.1313	NA	NA
+5614	St. George's Community Housing ltd	NA	S.11001	NA	2011-07-01
+5615	St. Helens Metropolitan Borough Council	NA	S.1313	NA	NA
+5616	St. Ives Port	NA	S.1313	NA	NA
+5617	St. Leger Homes of Doncaster Ltd	NA	S.11001	NA	NA
+5618	St. Margaret's Hope Pier (Sth Ronaldsay)	NA	S.11001	NA	2015-12-02
+5619	St. Mary's University College, Belfast	NA	S.1311	NA	2012-09-11
+5621	St.Abbs Harbour (Coldingham Shore)	NA	S.11001	NA	2015-12-02
+1802	NA	government-organisation:OT751	S.1311	NA	NA
+1613	NA	local-authority-eng:STA	S.1313	NA	NA
+5624	Staffordshire & West Midlands Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1614	NA	local-authority-eng:STS	S.1313	NA	NA
+1615	NA	local-authority-eng:STF	S.1313	NA	NA
+1833	NA	government-organisation:EA243	S.1311	2011-10-01	NA
+1616	NA	government-organisation:OT895	S.1311	NA	2012-04-01
+5626	Standards Commission for Scotland	NA	S.1311	NA	NA
+5627	Standing Advisory Commission on Human Rights (NI)	NA	S.1311	NA	NA
+5628	Standing Advisory Committee on Industrial Property	NA	S.1311	NA	NA
+5629	Standing Advisory Committee on Trunk Road Assessment	NA	S.1311	NA	NA
+5630	Standing Committee on Postgraduate Medical and Dental Education	NA	S.1311	NA	NA
+5631	Standing Dental Advisory Committee	NA	S.1311	NA	2010-04-01
+5632	Standing Medical Advisory Committee	NA	S.1311	NA	NA
+5633	Standing Nursing and Midwifery Advisory Committee	NA	S.1311	NA	NA
+5634	Standing Pharmaceutical Advisory Committee	NA	S.1311	NA	NA
+5638	Starman (Toiletries) Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+5639	State Hospital Board for Scotland	NA	S.1311	NA	NA
+5640	State Hospital Management Committee Scotland	NA	S.1311	NA	NA
+5641	Statistics Advisory Committee	NA	S.1311	NA	NA
+1617	NA	government-organisation:OT614	S.1311	NA	NA
+5642	Statute Law Committee	NA	S.1311	NA	NA
+5643	Statute Law Committee for Northern Ireland	NA	S.1311	NA	NA
+5644	Steering Committee on Pharmacy Postgraduate Education	NA	S.1311	NA	NA
+5648	Stevenage - (s NTC)	NA	S.1311	NA	NA
+1618	NA	local-authority-eng:STV	S.1313	NA	NA
+5650	Stevenage Homes Ltd	NA	S.11001	NA	2011-12-01
+5653	STFC Innovations Ltd	NA	S.1311	2002-01-01	NA
+5654	Stirling Business Centre Ltd	NA	S.1313	NA	NA
+5655	Stirling Council	NA	S.1313	NA	NA
+5656	Stirling Enterprise and Economic Development Company Ltd	NA	S.1313	NA	NA
+5658	Stockport Homes Ltd	NA	S.11001	NA	NA
+1619	NA	local-authority-eng:SKP	S.1313	NA	NA
+1620	NA	local-authority-eng:STT	S.1313	NA	NA
+1621	NA	local-authority-eng:STE	S.1313	NA	NA
+5661	Stonebridge Housing Action Trust	NA	S.1311	NA	NA
+5662	Stonehaven Port	NA	S.1313	NA	NA
+5668	Stornoway Port	NA	S.11001	NA	2015-12-02
+5669	Stranmillis University College (Belfast)	NA	S.1311	1905-04-05	NA
+5670	Stranraer Port	NA	S.1313	NA	NA
+5671	Strategic Health Authorities (England) (En Bloc)	NA	S.1311	NA	2013-04-01
+5672	Strategic Investment Board	NA	S.1311	NA	2008-06-01
+1754	NA	government-organisation:OT794	S.1311	NA	NA
+1622	NA	local-authority-eng:STR	S.1313	NA	NA
+5674	Strathclyde Partnership for Transport	NA	S.1313	2007-06-01	NA
+5675	Strathclyde Passenger Transport Executive - (s PTE)	NA	S.11001	NA	NA
+5676	Stromness Port	NA	S.1313	NA	NA
+5677	Stronsay Aerodrome	NA	S.1313	NA	NA
+1623	NA	local-authority-eng:STO	S.1313	NA	NA
+5680	Student Awards Agency For Scotland	NA	S.1311	NA	NA
+1766	NA	government-organisation:PB27	S.1311	NA	NA
+5681	Studio Schools (en Bloc)	NA	S.1311	NA	NA
+5682	Submarine Gift Shop Ltd.	NA	S.11001	NA	NA
+1624	NA	local-authority-eng:SUF	S.1313	NA	NA
+1625	NA	local-authority-eng:SFK	S.1313	NA	NA
+5684	Sugar Beet Research and Educational Committee	NA	S.1311	NA	NA
+5685	Sullom Voe Port	NA	S.1313	NA	NA
+5687	Sunderland (Unsworth) Aerodrome	NA	S.1313	NA	NA
+1626	NA	local-authority-eng:SND	S.1313	NA	NA
+5688	Sunderland City Training and Enterprise Council Ltd	NA	S.1311	NA	NA
+5689	Sunderland Empire Theatre Trust Ltd	NA	S.1313	NA	NA
+5690	Sunderland Port	NA	S.1313	NA	NA
+5694	Supported Employment Consultative Groups	NA	S.1311	NA	NA
+5695	Supreme Court Rule Committee	NA	S.1311	NA	NA
+5696	Supreme Court, the	NA	S.1311	2009-10-01	NA
+5697	Sureline Coaches Limited - (s NITHC)	NA	S.11001	NA	1987-07-01
+1627	NA	local-authority-eng:SRY	S.1313	NA	NA
+1628	NA	local-authority-eng:SUR	S.1313	NA	NA
+5701	Sustainable Development Commission	NA	S.1311	NA	NA
+5702	Sustainable Development Education Panel	NA	S.1311	NA	NA
+5704	Sutton Housing Partnership Ltd	NA	S.11001	NA	NA
+1629	NA	local-authority-eng:SWL	S.1313	NA	NA
+5709	Swansea (Fairwood Common) Aerodrome	NA	S.1313	NA	NA
+5710	Swansea Action Partnership	NA	S.1313	NA	NA
+1630	NA	local-authority-eng:SWD	S.1313	NA	NA
+5712	Swindon Centre for Disabled Living	NA	S.1313	NA	NA
+5713	Swindon Octobus Ltd	NA	S.1313	NA	2009-09-01
+5718	Sypta Ltd	NA	S.11001	NA	NA
+5719	Sypta Properties Ltd	NA	S.11001	NA	NA
+5725	Tai Cymru	NA	S.1311	NA	NA
+5726	Talacave Action Group	NA	S.1313	NA	NA
+5727	Talklight Ltd	NA	S.1313	NA	NA
+5729	Tamar Bridge and Torpoint Ferry Joint Committee	NA	S.11001	1905-05-14	NA
+5731	Tamar Science Park Ltd	NA	S.1313	NA	NA
+1631	NA	local-authority-eng:TAM	S.1313	NA	NA
+1632	NA	local-authority-eng:TAW	S.1313	NA	NA
+1633	NA	local-authority-eng:TAN	S.1313	NA	NA
+5735	Tarbert (Loch Fyne) Harbour	NA	S.11001	NA	2015-12-02
+5738	Tate Gallery	NA	S.1311	NA	NA
+1634	NA	local-authority-eng:TAU	S.1313	NA	NA
+5740	Tay Road Bridge Joint Board	NA	S.1311	2008-02-01	NA
+5741	Tayside and Central Scotland Transport Partnership (TACTRAN)	NA	S.1313	2005-12-01	NA
+5742	Tayside Contracts Joint Committee	NA	S.1313	NA	NA
+5743	Tayside Enterprise Board	NA	S.1313	NA	NA
+5744	Tayside Regional Council Harbour	NA	S.1313	NA	NA
+5747	Teacher Training Agency (TTA)	NA	S.1311	NA	2005-09-01
+5749	Teaching Agency	NA	S.1311	NA	2013-04-01
+5750	Teaching as a Career Unit	NA	S.1311	NA	NA
+1745	NA	government-organisation:PB136	S.1311	NA	NA
+5753	Teeside Development Corporation	NA	S.11001	NA	NA
+1635	NA	local-authority-eng:TEI	S.1313	NA	NA
+5756	Telford - (s NTC)	NA	S.1311	NA	NA
+1636	NA	local-authority-eng:TFW	S.1313	NA	NA
+1637	NA	government-organisation:EA934	S.1311	NA	2012-04-01
+5758	Tenby Port	NA	S.1313	NA	NA
+1638	NA	local-authority-eng:TEN	S.1313	NA	NA
+1639	NA	local-authority-eng:TES	S.1313	NA	NA
+1640	NA	local-authority-eng:TEW	S.1313	NA	NA
+5763	Thames Valley Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+5765	Thamesdown Law Centre	NA	S.1313	NA	NA
+5766	Thamesdown Transport Ltd	NA	S.11001	NA	NA
+1641	NA	local-authority-eng:THA	S.1313	NA	NA
+5767	The Attorney General's Office	NA	S.1311	NA	NA
+5769	The Crime Concern, Marks and Spencer, Groundwork Partnership (t/a Youth Works)	NA	S.1311	NA	NA
+5770	The English Heritage Trust	NA	S.11001	2014-11-24	NA
+5772	The Learning Trust	NA	S.11001	NA	NA
+5774	The London Authorities Mutual Limited	NA	S.12801	NA	NA
+5775	The National Association of Citizens Advice Bureau (England and Wales)	NA	S.1311	NA	2013-11-01
+5776	The National Institute for Clinical Excellence	NA	S.1311	NA	2005-04-01
+5777	The National Institute for Health and Clinical Excellence	NA	S.1311	2005-04-01	NA
+5778	The North South Language Body (An Foras Teanga North-South Body o Leid)	NA	S.1311	1999-12-01	NA
+5779	The Nursery Channel Ltd. (S - S4C)	NA	S.11001	NA	NA
+5780	The Potteries Box Company Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+5781	The Scottish Association of Citizens Advice Bureau	NA	S.1311	NA	2013-11-01
+5782	The Skills Development Scotland Co. Limited (t/a Skills Development Scotland)	NA	S.1311	NA	NA
+5783	Theatres Trust	NA	S.1311	NA	NA
+1642	NA	local-authority-eng:THE	S.1313	NA	NA
+1643	NA	local-authority-eng:THR	S.1313	NA	NA
+1644	NA	government-organisation:OT840	S.1311	NA	2012-10-01
+5795	Tingwall Aerodrome	NA	S.1313	NA	NA
+1645	NA	local-authority-eng:TON	S.1313	NA	NA
+5803	Topsham Port	NA	S.1313	NA	NA
+1646	NA	local-authority-eng:TOB	S.1313	NA	NA
+1647	NA	principal-local-authority:TOF	S.1313	NA	NA
+5804	Torquay Port	NA	S.1313	NA	NA
+1648	NA	local-authority-eng:TOR	S.1313	NA	NA
+5806	Tote Bookmakers Ltd - (s HTB)	NA	S.11001	NA	NA
+5807	Tote Credit Ltd - (s HTB)	NA	S.11001	NA	NA
+5808	Tote Direct Ltd - (s HTB)	NA	S.11001	NA	NA
+5809	Tourism Ireland Ltd	NA	S.1311	1999-12-01	NA
+5811	Tower Hamlets Homes Ltd	NA	S.11001	NA	NA
+5816	Traffic Commissioners/ Licensing Authorities	NA	S.1311	NA	NA
+5817	Traffic Director for London	NA	S.1311	NA	NA
+5818	Traffic Wardens	NA	S.1313	NA	NA
+1649	NA	local-authority-eng:TRF	S.1313	NA	NA
+5820	Trafford Park Development Corporation	NA	S.11001	NA	NA
+5821	Training and Development Agency	NA	S.1311	NA	NA
+1650	NA	government-organisation:EA790	S.1311	NA	2012-04-01
+5822	Training and Employment Agency (Advisory Board)	NA	S.1311	NA	NA
+5823	Training and Enterprise Councils (En Bloc)	NA	S.1311	NA	NA
+5824	Tramtrack Croydon Ltd	NA	S.11001	2008-06-01	NA
+5826	Transitional Child Trust Fund	NA	S.1311	NA	NA
+5827	Transport for Greater Manchester	NA	S.1313	NA	NA
+5828	Transport for London	NA	S.1313	NA	NA
+5829	Transport for London Finance Limited	NA	S.1313	2008-11-01	NA
+5830	Transport for London Pension Scheme	NA	S.12901	1989-04-01	NA
+5831	Transport Trading Ltd (s.TfL)	NA	S.1313	1905-06-22	NA
+5832	Transport Tribunal	NA	S.1311	NA	NA
+1651	NA	government-organisation:PB383	S.1311	NA	NA
+5833	Treasury Trove Reviewing Committee	NA	S.1311	NA	NA
+5838	Tribunal under Schedule 11 of the Health and Personal Social Services (NI) Order 1972	NA	S.1311	NA	NA
+5839	Tribunals Service, the	NA	S.1311	NA	2011-04-01
+5844	Trinity House Lighthouse Service	NA	S.1311	1905-04-29	NA
+5845	Trinity House National Lighthouse Centre Ltd	NA	S.1313	NA	2006-08-01
+5848	Tristar Homes Ltd	NA	S.11001	1996-07-04	2010-12-01
+3602	Truro Port	NA	S.1313	NA	NA
+3604	Trust Ports in Northern Ireland (En Bloc)	NA	S.11001	NA	NA
+3605	TS Prestwick Holdco Ltd	NA	S.1311	2013-11-14	NA
+3606	TSB Bank plc	NA	S.12201	NA	2014-03-01
+3607	Tube Lines (Holdings) Ltd (including Tube Lines Ltd and Tube Lines Finance Plc)	NA	S.1313	1905-07-02	NA
+1652	NA	local-authority-eng:TUN	S.1313	NA	NA
+3617	Tyne & Wear Development Corporation	NA	S.11001	NA	NA
+3618	Tyne and Wear Passenger Transport Executive - (s PTE) - Nexus	NA	S.1313	1998-04-01	NA
+3619	Tyne Harbour Commissioners	NA	S.11001	NA	NA
+3623	UIC Transport (JNP) Ltd	NA	S.11001	NA	1905-07-04
+1805	NA	government-organisation:PB377	S.1311	2009-08-01	NA
+3624	UK Asset Resolution Ltd	NA	S.1311	2010-10-01	NA
+3625	UK Central Council for Nursing, Midwifery and Health Visiting	NA	S.1311	NA	2002-04-01
+1653	NA	government-organisation:PB138	S.1311	NA	NA
+1654	NA	government-organisation:EA82	S.1311	NA	NA
+1655	NA	government-organisation:OT850	S.1311	NA	2011-04-01
+1811	NA	government-organisation:PC259	S.1311	NA	NA
+3626	UK Human Genome Mapping Project resource centre	NA	S.1311	NA	NA
+3627	UK Medical Ventures Fund/MVM Limited	NA	S.1311	NA	NA
+3628	UK Programme Distribution Ltd (95%) (s BBCW)	NA	S.11001	NA	NA
+3629	UK Robotic Ltd - (s BNFL)	NA	S.11001	NA	NA
+1656	NA	government-organisation:EA31	S.1311	2011-04-01	NA
+1783	UK Statistics Authority	NA	S.1311	NA	NA
+1856	NA	government-organisation:D117	S.1311	NA	NA
+3630	Ullapool Harbour	NA	S.11001	NA	2015-12-02
+3631	Ulster American Folk Park	NA	S.1311	NA	NA
+3632	Ulster Bank Ireland Ltd	NA	S.12201	NA	NA
+3633	Ulster Bank Ltd	NA	S.12201	NA	NA
+3634	Ulster Countryside Agency	NA	S.1311	NA	NA
+3635	Ulster Folk and Transport Museum	NA	S.1311	NA	NA
+3636	Ulster Museum	NA	S.1311	NA	NA
+3637	Ulster Savings Committee	NA	S.1311	NA	NA
+3638	Ulster Supported Employment Ltd	NA	S.1311	NA	NA
+3639	Ulsterbus Ltd - (s NITHC)	NA	S.11001	NA	NA
+3640	Unclaimed Redemption Monies	NA	S.1311	NA	NA
+3641	Unclaimed Stock and Dividends Account	NA	S.1311	NA	NA
+3643	Unified Appeal Tribunal	NA	S.1311	NA	NA
+3644	Union Railways (North) Limited	NA	S.11001	NA	2008-07-01
+3645	Union Railways (South) Limited	NA	S.11001	NA	2011-09-01
+3647	United Kingdom Advisory Panel for Health Care Workers infected with bloodbourne viruses	NA	S.1311	NA	NA
+3648	NA	government-organisation:PB137	S.1311	NA	NA
+3649	NA	government-organisation:EA67	S.1311	NA	2013-04-01
+3650	United Kingdom Eco-labelling Board	NA	S.1311	NA	NA
+3651	United Kingdom Nirex Ltd - (s NDA)	NA	S.11001	NA	NA
+3652	United Kingdom Register of Organic Food Standards	NA	S.1311	NA	NA
+3653	United Kingdom Round Table on Sustainable Development	NA	S.1311	NA	NA
+3654	United Kingdom Sports Council, The (UK Sport)	NA	S.1311	NA	NA
+3655	United Kingdom Transplant Support Service Authority	NA	S.1311	NA	NA
+3656	United Kingdom Xenotransplantation Interim Regulatory Authority (UK)	NA	S.1311	NA	2006-12-01
+3657	United Residents Housing Ltd	NA	S.11001	NA	NA
+3660	University for Industry Charitable Trust	NA	S.1311	NA	2012-03-01
+3661	University for Industry Limited (renamed as Learndirect Ltd in April 2012)	NA	S.1311	NA	2012-11-01
+3662	University Technical Colleges (en Bloc)	NA	S.1311	NA	NA
+3663	Urban Development Corporations	NA	S.1311	NA	NA
+3664	Urban Investment Grant Appraisal Panel	NA	S.1311	NA	NA
+3665	Urban Regeneration Agency	NA	S.1311	NA	NA
+3667	Urr Navigation	NA	S.11001	NA	2015-12-02
+1657	NA	local-authority-eng:UTT	S.1313	NA	NA
+3668	Vaccine Damage Tribunal	NA	S.1311	NA	NA
+1658	NA	principal-local-authority:VGL	S.1313	NA	NA
+3670	Vale of Glamorgan Victim Support	NA	S.1313	NA	NA
+1659	NA	local-authority-eng:VAL	S.1313	NA	NA
+1800	NA	government-organisation:EA687	S.1311	NA	NA
+1660	NA	government-organisation:EA87	S.1311	NA	NA
+3672	Valuation Tribunals	NA	S.1311	NA	NA
+3673	Valuation Tribunals (Wales)	NA	S.1311	NA	NA
+3675	VAT and Duties Tribunal	NA	S.1311	NA	NA
+1732	NA	government-organisation:EA79	S.11001	NA	NA
+1661	NA	government-organisation:EA80	S.1311	NA	NA
+3677	Velindre NHS Trust	NA	S.1311	1994-04-01	NA
+3678	Verderers of the New Forest	NA	S.1313	NA	NA
+1662	NA	government-organisation:PB403	S.1311	2009-12-01	NA
+1663	NA	government-organisation:EA784	S.1311	NA	NA
+1664	NA	government-organisation:EA60	S.1311	NA	NA
+1665	NA	government-organisation:PB212	S.1311	NA	NA
+1666	NA	government-organisation:OT1011	S.1311	NA	2015-03-31
+3679	Victims and Survivors Service Ltd	NA	S.1311	2012-04-01	NA
+1667	NA	government-organisation:PB378	S.1311	NA	NA
+3681	Victoria Coach Station Ltd (s.TfL)	NA	S.11001	NA	NA
+3685	Viking Energy Ltd	NA	S.1313	NA	NA
+1769	NA	government-organisation:PB186	S.1311	NA	NA
+3690	VisitScotland Ltd	NA	S.1311	NA	NA
+3692	Voluntary Action Barnsley	NA	S.1313	NA	NA
+3693	Voluntary Action Camden	NA	S.1313	NA	NA
+3694	Voluntary Aided Schools (En Bloc)	NA	S.1313	NA	NA
+3695	Voluntary Controlled Schools (En Bloc)	NA	S.1313	1999-11-01	NA
+3698	Wages Councils	NA	S.1311	NA	NA
+1668	NA	local-authority-eng:WKF	S.1313	NA	NA
+1669	NA	government-organisation:OT908	S.11001	NA	NA
+3702	Wales Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+3703	NA	government-organisation:OT590	S.1311	NA	NA
+3704	Wales Tourist Board	NA	S.1311	NA	NA
+3705	Wales Youth Agency	NA	S.1311	NA	NA
+1670	NA	government-organisation:PB187	S.1311	NA	NA
+1671	NA	local-authority-eng:WLL	S.1313	NA	NA
+3709	Waltham Forest Arms Length Management Organisation Ltd	NA	S.11001	NA	NA
+3714	War Pensions Agency (admin)	NA	S.1311	NA	2007-04-01
+3715	War Pensions Committee	NA	S.1311	NA	2009-12-01
+3717	Warren Point Harbour Authority	NA	S.11001	NA	NA
+3718	Warrington - (s NTC)	NA	S.1311	NA	NA
+1672	NA	local-authority-eng:WRT	S.1313	NA	NA
+3719	Warrington Borough Transport Ltd	NA	S.11001	NA	NA
+1673	NA	government-organisation:EA735	S.1311	NA	2004-04-01
+1674	NA	local-authority-eng:WAW	S.1313	NA	NA
+3722	Warwick Technology Park Management Company Ltd	NA	S.1313	NA	NA
+3723	Warwickshire and West Mercia Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+1675	NA	local-authority-eng:WAR	S.1313	NA	NA
+3725	Washington - (s NTC)	NA	S.1311	NA	NA
+3726	Waste & Resources Action Programme (WRAP)	NA	S.1311	NA	NA
+3727	Waste Disposal	NA	S.1313	NA	NA
+3728	Watchet Port	NA	S.1313	NA	NA
+3729	Water Appeals Commission (Northern Ireland)	NA	S.1311	NA	NA
+3730	Water Industry Commission for Scotland	NA	S.1311	NA	NA
+3731	Water Regulations Advisory Committee	NA	S.1311	NA	NA
+3737	Waterwatch Scotland	NA	S.1311	NA	2011-08-01
+1676	NA	government-organisation:OT869	S.1311	1999-12-01	NA
+1677	NA	local-authority-eng:WAT	S.1313	NA	NA
+1678	NA	local-authority-eng:WAV	S.1313	NA	NA
+1679	NA	local-authority-eng:WAE	S.1313	NA	NA
+1680	NA	local-authority-eng:WEA	S.1313	NA	NA
+3743	WeatherXchange Limited	NA	S.11001	NA	2009-11-01
+1681	NA	local-authority-eng:WEL	S.1313	NA	NA
+3752	Welsh Advisory Committee on Drug and Alcohol Misuse	NA	S.1311	NA	NA
+3753	Welsh Advisory Committee on Telecommunications (WACT)	NA	S.1311	NA	NA
+3754	Welsh Ambulance Services NHS Trust	NA	S.1311	1998-04-01	NA
+3755	Welsh Blood Service	NA	S.1311	NA	NA
+3756	Welsh Committee for Postgraduate Pharmaceutical Education	NA	S.1311	NA	NA
+3757	Welsh Committee for Professional Development of Pharmacy	NA	S.1311	NA	NA
+3758	Welsh Community Health Councils	NA	S.1311	NA	NA
+3759	Welsh Consumer Council (WCC)	NA	S.1311	NA	NA
+3760	Welsh Dental Committee	NA	S.1311	NA	NA
+1682	NA	government-organisation:OT991	S.1311	NA	2006-04-01
+3761	Welsh Further Education Colleges	NA	S.1311	NA	2015-01-27
+1683	NA	government-organisation:DA1019	S.1311	NA	NA
+3762	Welsh Health Common Services Authority	NA	S.1311	NA	NA
+3763	Welsh Health Promotion Authority	NA	S.1311	NA	NA
+3764	Welsh Industrial Development Advisory Board	NA	S.1311	NA	NA
+3765	Welsh Language Board (WLB)	NA	S.1311	NA	2012-04-01
+1684	NA	government-organisation:OT1101	S.1311	2012-04-01	NA
+3766	Welsh Local Government Association	NA	S.1313	1996-02-23	NA
+3767	Welsh Medical Committee	NA	S.1311	NA	NA
+3768	Welsh National Board for Nursing, Midwifery and Health Visiting	NA	S.1311	NA	2002-04-01
+3769	Welsh Nursing and Midwifery Committee	NA	S.1311	NA	NA
+3770	Welsh Optical Committee	NA	S.1311	NA	NA
+3771	Welsh Optometric Committee	NA	S.1311	NA	NA
+3772	Welsh Pharmaceutical Committee	NA	S.1311	NA	NA
+3773	Welsh Scheme for the Development of Health and Social Research	NA	S.1311	NA	NA
+3774	Welsh Scientific Advisory Committee	NA	S.1311	NA	NA
+3775	Welsh Venture Capital	NA	S.11001	NA	NA
+3776	Welsh Venture Capital - (s WDA)	NA	S.11001	NA	NA
+3777	Welwyn Garden City - (s NTC)	NA	S.1311	NA	NA
+1685	NA	local-authority-eng:WEW	S.1313	NA	NA
+3779	Welwyn Hatfield Community Housing trust Ltd	NA	S.11001	NA	NA
+1686	NA	local-authority-eng:WBK	S.1313	NA	NA
+1687	NA	local-authority-eng:WDE	S.1313	NA	NA
+1688	NA	local-authority-eng:WDO	S.1313	NA	NA
+1835	NA	local-authority-sct:WDU	S.1313	NA	NA
+1689	NA	local-authority-eng:WLA	S.1313	NA	NA
+1690	NA	local-authority-eng:WLI	S.1313	NA	NA
+3789	West London Waste Authority	NA	S.1313	1986-01-01	NA
+1874	NA	local-authority-sct:WLN	S.1313	NA	NA
+3792	West Lothian Municipal Bank Ltd	NA	S.12501	NA	NA
+3794	West Midlands Life Cultural Consortium	NA	S.1311	NA	2010-09-01
+3795	West Midlands Passenger Transport Executive (trading as Centro) - (s PTE)	NA	S.1313	1998-04-01	NA
+3796	West North West Homes Leeds	NA	S.11001	NA	NA
+1691	NA	government-organisation:PB501	S.1311	NA	2014-03-31
+3799	West of Scotland Water Authority	NA	S.11001	NA	NA
+1692	NA	local-authority-eng:WOX	S.1313	NA	NA
+1693	NA	local-authority-eng:WSO	S.1313	NA	NA
+1694	NA	local-authority-eng:WSX	S.1313	NA	NA
+3802	West Yorkshire Community Rehabilitation Company (CRC)	NA	S.1311	NA	2015-02-01
+3803	West Yorkshire Passenger Transport Executive - (s PTE)	NA	S.1313	NA	NA
+1695	NA	government-organisation:OT858	S.1311	NA	NA
+1861	NA	government-organisation:OT866	S.1311	NA	NA
+3805	Western Health and Social Care Trust	NA	S.1311	2010-04-01	NA
+3806	Western Riverside Waste Authority	NA	S.1313	1986-01-01	NA
+3808	Westinghouse Electric UK Limited	NA	S.11001	NA	NA
+3811	Westminster City Council	NA	S.1313	NA	NA
+1761	NA	government-organisation:OT316	S.1311	NA	NA
+3814	Westray Port	NA	S.1313	NA	NA
+3821	Weyland Farms Ltd	NA	S.1313	NA	NA
+1696	NA	local-authority-eng:WEY	S.1313	NA	NA
+3822	Weymouth Port	NA	S.1313	NA	NA
+3823	WGC Holdco Ltd	NA	S.1311	2013-03-01	NA
+3830	Whitby Port	NA	S.1313	NA	NA
+3833	Whitehall Port (Stronsay)	NA	S.1313	NA	NA
+3835	Whitehills Harbour	NA	S.11001	NA	2015-12-02
+3837	Whitstable Port	NA	S.1313	NA	NA
+3838	Whitwick Business Park Management Co Ltd, The	NA	S.1313	NA	NA
+3840	Wick Harbour	NA	S.11001	NA	2015-12-02
+3842	Wider Health Working Group	NA	S.1311	NA	NA
+1697	NA	local-authority-eng:WGN	S.1313	NA	NA
+3844	Wigtown Port	NA	S.1313	NA	NA
+3854	Wilton Park Academic Council	NA	S.1311	NA	NA
+3855	Wilton Park Executive Agency	NA	S.1311	NA	NA
+3856	Wilton Park International Advisory Council	NA	S.1311	NA	NA
+1698	NA	local-authority-eng:WIL	S.1313	NA	NA
+3857	Wimbledon Civic Theatre Trust	NA	S.1313	NA	NA
+1699	NA	local-authority-eng:WIN	S.1313	NA	NA
+3862	Wine Standards Board of the Vintners' Company	NA	S.1311	NA	NA
+3867	NA	local-authority-eng:WRL	S.1313	NA	NA
+3871	Wisbech Port	NA	S.1313	NA	NA
+3876	WJEC CBAC Ltd (Welsh Joint Education Committee)	NA	S.11001	NA	NA
+1700	NA	local-authority-eng:WOI	S.1313	NA	NA
+1701	NA	local-authority-eng:WOK	S.1313	NA	NA
+3881	Wolverhampton City Challenge	NA	S.1313	NA	1998-03-01
+3882	NA	local-authority-eng:WLV	S.1313	NA	NA
+3883	Wolverhampton Homes Ltd	NA	S.11001	NA	NA
+3884	Women's National Commission	NA	S.1311	NA	NA
+3886	Woodford-Gubbins Ltd - (s Remploy Ltd)	NA	S.11001	NA	NA
+3892	Woolwich Arsenal Rail Enterprises (Holdings) Limited	NA	S.1313	1905-07-03	NA
+3893	Woolwich Arsenal Rail Enterprises Limited	NA	S.1313	1905-07-03	NA
+1702	NA	local-authority-eng:WOC	S.1313	NA	NA
+3895	Worcestershire County Association of Local Councils	NA	S.1313	NA	NA
+1703	NA	local-authority-eng:WOR	S.1313	NA	NA
+3897	Workforce Development Confederations	NA	S.1311	NA	2004-04-01
+1767	NA	government-organisation:OT930	S.1311	NA	2010-08-01
+3898	Workington Port	NA	S.1313	NA	NA
+3899	Worknorth 11 Ltd (s MA)	NA	S.11001	NA	2013-02-01
+3900	Worknorth Ltd (s MA)	NA	S.11001	NA	2013-02-01
+3901	World Poultry Science Association	NA	S.1311	NA	NA
+3902	Worldwide Americas Investments Inc [USA] (s BBCW)	NA	S.11001	NA	NA
+1704	NA	local-authority-eng:WOT	S.1313	NA	NA
+1705	NA	principal-local-authority:WRX	S.1313	NA	NA
+1706	NA	local-authority-eng:WYC	S.1313	NA	NA
+1707	NA	local-authority-eng:WYO	S.1313	NA	NA
+3910	NA	local-authority-eng:WYR	S.1313	NA	NA
+1708	NA	local-authority-eng:WYE	S.1313	NA	NA
+3930	Yorkshire & Humber Port	NA	S.1313	NA	NA
+3932	Yorkshire Cultural Consortium	NA	S.1311	NA	2009-07-01
+1709	NA	government-organisation:OT547	S.1313	1996-06-01	NA
+1710	NA	government-organisation:EA923	S.1311	NA	2012-07-01
+3935	Yorkshire Metro Ltd - (s SYPTE)	NA	S.11001	NA	NA
+3936	Yorkshire Purchasing Organisation	NA	S.11001	NA	NA
+3937	Yorkshire Region Electricity Consumers’ Committee	NA	S.1311	NA	NA
+3938	NA	government-organisation:EA960	S.1311	NA	2012-04-01
+3940	Your Homes Newcastle Ltd	NA	S.11001	NA	NA
+3942	Youth and Family Courts Lay Panel Advisory Committee (Northern Ireland)	NA	S.1311	NA	2004-10-01
+3943	Youth Council for Northern Ireland	NA	S.1311	NA	NA
+1837	NA	government-organisation:EA697	S.1311	NA	NA
+1711	NA	government-organisation:PB302	S.1311	NA	NA
+3946	Zetland Transport Partnership	NA	S.1313	2005-12-01	NA
+3947	Zoos Forum	NA	S.1311	NA	NA

--- a/data/public-body.tsv
+++ b/data/public-body.tsv
@@ -2170,7 +2170,7 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 5070	Prestwick Aviation Holdings Limited	NA	S.1311	2013-11-22	NA
 5071	Primary Care Trusts (En Bloc)	NA	S.1311	NA	2013-04-01
 5075	Priority Sites Ltd	NA	S.11001	2008-09-01	NA
-5860	Private registered providers' of social housing (including most housing associations) in England	NA	S.11001	1996-07-24T00:00:00Z	2017-11-16T00:00:00Z
+5860	Private registered providers' of social housing (including most housing associations) in England	NA	S.11001	1996-07-24	2017-11-16
 1522	NA	government-organisation:OT342	S.1311	NA	NA
 1523	NA	government-organisation:OT659	S.1311	NA	NA
 5076	Probation Trusts	NA	S.1311	NA	NA
@@ -3019,4 +3019,4 @@ public-body	name	organisations	public-body-classifications	start-date	end-date
 1711	NA	government-organisation:PB302	S.1311	NA	NA
 3946	Zetland Transport Partnership	NA	S.1313	2005-12-01	NA
 3947	Zoos Forum	NA	S.1311	NA	NA
-5864	Crown Estate Scotland (Interim Management)		S.11001	2017-04-01T00:00:00Z	NA
+5864	Crown Estate Scotland (Interim Management)		S.11001	2017-04-01	NA

--- a/lists/name-to-curie-map.tsv
+++ b/lists/name-to-curie-map.tsv
@@ -4847,3 +4847,10 @@ public-body	name	organisation	public-body-classification	start-date	end-date
 5846	Trinity Housing Association Limited	NA	S.11001	1996-07-24T00:00:00Z	NA
 5847	Tristar Homes Limited	NA	S.11001	1996-07-24T00:00:00Z	NA
 5848	Tristar Homes Ltd	NA	S.11001	NA	2010-12-01T00:00:00Z
+5860	Private registered providers (PRPs) of social housing in England	NA	S.11001	1996-07-24T00:00:00Z	2017-11-16T00:00:00Z
+5860	Private registered providers' of social housing (including most housing associations) in England	NA	S.11001	1996-07-24T00:00:00Z	2017-11-16T00:00:00Z
+5861	Registered Housing Associations (RHAs) in Northern Ireland	NA	S.11001	1992-07-15T00:00:00Z	NA
+5862	Registered Social Landlords (RSL) in Scotland	NA	S.11001	2001-07-18T00:00:00Z	NA
+5863	Registered Social Landlords (RSLs) in Wales	NA	S.11001	1996-07-24T00:00:00Z	NA
+1737	Green Investment Bank	government-organisation:OT360	S.1311	2012-11-01T00:00:00Z	NA
+5864	Crown Estate Scotland (Interim Management)		S.11001	2017-04-01T00:00:00Z	NA


### PR DESCRIPTION
* A lot of CURIEs had been removed by a previous update.  They have been replaced.
* Then the 2017-11-30 data was reconciled with the register, and necessary changes made
* Then I noticed some bad date formats and fixed them
* Then I re-fixed the mixed classifications, e.g. `S.11001/3` becomes `S.11001;S.11003`
* Finally I noticed that there were two records against the same government-organisation CURIE, so I've removed the CURIEs and put the names in.  They're to do with Historic Royal Palaces accounts, which seem to be two clearly different things rather than two accidental versions of a generic "Historic Royal Palaces" thing.